### PR TITLE
Ecopercent 322 뒤로가기 연동 안됌

### DIFF
--- a/src/Components/TabBar/TabBar.jsx
+++ b/src/Components/TabBar/TabBar.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import { TabBarContainer } from "./style";
 import TabItem from "./TabItem";
 
-const TabBar = ({ setCurrTabNumber, currTabNumber, routeInfo }) => {
+const TabBar = ({ currTabNumber, routeInfo }) => {
   return (
     <TabBarContainer>
       {routeInfo.map((element, index) => {
@@ -12,7 +12,6 @@ const TabBar = ({ setCurrTabNumber, currTabNumber, routeInfo }) => {
             itemNumber={index}
             IconComponent={element.icon}
             page={element.page}
-            setCurrTabNumber={setCurrTabNumber}
             currTabNumber={currTabNumber}
           />
         );

--- a/src/Components/TabBar/TabItem.jsx
+++ b/src/Components/TabBar/TabItem.jsx
@@ -2,16 +2,9 @@ import React, { useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { TabItemBackGround } from "./style";
 
-const TabItem = ({
-  itemNumber,
-  IconComponent,
-  setCurrTabNumber,
-  currTabNumber,
-  page,
-}) => {
+const TabItem = ({ itemNumber, IconComponent, currTabNumber, page }) => {
   const navigate = useNavigate();
   const tabClickHandler = useCallback(() => {
-    setCurrTabNumber(itemNumber);
     navigate(`/main/${page}`);
   }, []);
   return (

--- a/src/Layouts/Main/Main.jsx
+++ b/src/Layouts/Main/Main.jsx
@@ -46,11 +46,7 @@ const Main = () => {
     <div>
       <PageWrap>{routeInfo[currTabNumber].jsx}</PageWrap>
       <FooterWrap>
-        <TabBar
-          setCurrTabNumber={setCurrTabNumber}
-          currTabNumber={currTabNumber}
-          routeInfo={routeInfo}
-        />
+        <TabBar currTabNumber={currTabNumber} routeInfo={routeInfo} />
       </FooterWrap>
     </div>
   );


### PR DESCRIPTION
## 개요
- PR 리뷰하다가 하단 탭 이동 후 뒤로가기하면 탭이 안따라오는거 확인

## 작업사항
- useEffect로 페이지 변경마다 set함
- 위의 방식으로 변경하면서 불필요한 props와 set함수 호출 제거

## 변경로직


<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->