### PR TITLE
fix: 대표 아이템와 테두리 크기 맞추기

### DIFF
--- a/src/Components/Home/TitleItems/TitleItem/ItmeImageStroke.jsx
+++ b/src/Components/Home/TitleItems/TitleItem/ItmeImageStroke.jsx
@@ -101,7 +101,7 @@ const ItmeImageStroke = ({ itemInfo, userId }) => {
   return (
     <svg width="200" height="200" viewBox="0 0 200 200" onClick={increaseCount}>
       <g>
-        <foreignObject x="50" y="50" width="100%" height="100%">
+        <foreignObject x="25" y="25" width="100%" height="100%">
           <S.ImageClipper src={itemInfo.image} alt="아이템 이미지" />
         </foreignObject>
         {(divideNum === 3 ? threeStrockInfo : oneStrockInfo).map((element) => {

--- a/src/Components/Home/TitleItems/TitleItem/style.jsx
+++ b/src/Components/Home/TitleItems/TitleItem/style.jsx
@@ -12,8 +12,8 @@ export const Spacer = styled.span`
 
 export const ImageClipper = styled.img`
   position: relative;
-  width: 100px;
-  height: 100px;
+  width: 150px;
+  height: 150px;
   object-fit: cover; /* 이미지 비율 유지 */
   border-radius: 50%;
   border: 1px solid;


### PR DESCRIPTION
## 개요
- 대표 아이템와 테두리 크기 맞추기

## 작업사항
- 대표아이템 크기를 테두리와 맞추게 변경 크기를 100, 100 에서 150, 150으로
위치를 50, 50에서 25, 25로