### PR TITLE
feat: 카카오 간편 로그인 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0"
   },
-  "proxy": "http://localhost:8080"
+  "proxy": "http://15.164.220.23:8080"
 }

--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0"
   },
-  "proxy": "http://15.164.220.23:8080"
+  "proxy": "http://localhost:8080"
 }

--- a/package.json
+++ b/package.json
@@ -59,5 +59,5 @@
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-react-hooks": "^4.6.0"
   },
-  "proxy": "http://3.37.86.40:8080"
+  "proxy": "http://15.164.220.23:8080"
 }

--- a/src/Components/Login/SocialLogin.jsx
+++ b/src/Components/Login/SocialLogin.jsx
@@ -1,17 +1,19 @@
 import React, { useEffect } from "react";
-import { useLocation } from "react-router-dom";
-import kakaoLogin from "./kakaoLogin";
+import { useLocation, useNavigate } from "react-router-dom";
+import { kakaoLogin, getKakaoToken } from "./kakaoLogin";
 import * as S from "./style";
 
 export default function SocialLogin() {
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (location.pathname.split("/")[2] === "kakao") {
       const params = new URLSearchParams(location.search);
       if (params.has("code")) {
-        console.log("카카오 코드 받았어!");
+        console.log("카카오 인가 코드 받았어!");
         console.log(params.get("code"));
+        getKakaoToken({ authCode: params.get("code"), navigate });
       }
     }
   }, []);
@@ -22,65 +24,3 @@ export default function SocialLogin() {
     </S.LoginButton>
   );
 }
-
-// 효박이의 예제 코드
-
-// export default function SocialLogin() {
-//   const navigate = useNavigate();
-//   const queryParams = new URLSearchParams(window.location.search);
-//   const code = queryParams.get("code");
-//   console.log(code);
-//   useEffect(() => {
-//     if (code) {
-//       console.log("gogo", code);
-//       axios
-//         .post(
-//           `https://kauth.kakao.com/oauth/token`,
-//           {
-//             grant_type: "authorization_code",
-//             client_id: `${process.env.REACT_APP_KAKAO_JS_KEY}`,
-//             redirect_uri: `${process.env.REACT_APP_KAKAO_REDIRECT_URI}`,
-//             code: `${code}`,
-//           },
-//           {
-//             headers: {
-//               "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-//             },
-//           }
-//         )
-//         .then((kakaoAuthResult) => {
-//           console.log(kakaoAuthResult.data);
-//           console.log(
-//             "여기 kakaoAuthResult.data에 엑세스 들어있습니다~ 엑세스토큰으로 then 안에서 아래처럼 다시 우리 서버에 axios 날리면 돼!"
-//           );
-//           axios
-//             .get(`/login/oauth2/kakao`, {
-//               headers: {
-//                 Authorization: `Bearer ${
-//                   kakaoAuthResult.data.access_token ?? "오잉 왜 토큰이 없지"
-//                 }`,
-//               },
-//             })
-//             .then((ecopercentAuthResult) => {
-//               if (ecopercentAuthResult.status === 200) {
-//                 console.log("쿠키에 있는 우리서버 엑세스 저장 후 메인가기");
-//                 navigate("/home");
-//               } else if (ecopercentAuthResult.status === 404) {
-//                 console.log("회원가입 하러 가기");
-//                 navigate("/signup");
-//               }
-//             })
-//             .catch((e) => {
-//               console.log("ecopercent kakao auth erro", e);
-//             });
-//         });
-//       console.log("gogo!!");
-//     }
-//   }, [code]);
-
-//   return (
-//     <S.LoginButton onClick={kakaoLogin}>
-//       <S.LogoImg src="/img/kakaoLogo.png" alt="kakao login" />
-//     </S.LoginButton>
-//   );
-// }

--- a/src/Components/Login/SocialLogin.jsx
+++ b/src/Components/Login/SocialLogin.jsx
@@ -1,11 +1,86 @@
-import React from "react";
+import React, { useEffect } from "react";
+import { useLocation } from "react-router-dom";
 import kakaoLogin from "./kakaoLogin";
 import * as S from "./style";
 
 export default function SocialLogin() {
+  const location = useLocation();
+
+  useEffect(() => {
+    if (location.pathname.split("/")[2] === "kakao") {
+      const params = new URLSearchParams(location.search);
+      if (params.has("code")) {
+        console.log("카카오 코드 받았어!");
+        console.log(params.get("code"));
+      }
+    }
+  }, []);
+
   return (
     <S.LoginButton onClick={kakaoLogin}>
       <S.LogoImg src="/img/kakaoLogo.png" alt="kakao login" />
     </S.LoginButton>
   );
 }
+
+// 효박이의 예제 코드
+
+// export default function SocialLogin() {
+//   const navigate = useNavigate();
+//   const queryParams = new URLSearchParams(window.location.search);
+//   const code = queryParams.get("code");
+//   console.log(code);
+//   useEffect(() => {
+//     if (code) {
+//       console.log("gogo", code);
+//       axios
+//         .post(
+//           `https://kauth.kakao.com/oauth/token`,
+//           {
+//             grant_type: "authorization_code",
+//             client_id: `${process.env.REACT_APP_KAKAO_JS_KEY}`,
+//             redirect_uri: `${process.env.REACT_APP_KAKAO_REDIRECT_URI}`,
+//             code: `${code}`,
+//           },
+//           {
+//             headers: {
+//               "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+//             },
+//           }
+//         )
+//         .then((kakaoAuthResult) => {
+//           console.log(kakaoAuthResult.data);
+//           console.log(
+//             "여기 kakaoAuthResult.data에 엑세스 들어있습니다~ 엑세스토큰으로 then 안에서 아래처럼 다시 우리 서버에 axios 날리면 돼!"
+//           );
+//           axios
+//             .get(`/login/oauth2/kakao`, {
+//               headers: {
+//                 Authorization: `Bearer ${
+//                   kakaoAuthResult.data.access_token ?? "오잉 왜 토큰이 없지"
+//                 }`,
+//               },
+//             })
+//             .then((ecopercentAuthResult) => {
+//               if (ecopercentAuthResult.status === 200) {
+//                 console.log("쿠키에 있는 우리서버 엑세스 저장 후 메인가기");
+//                 navigate("/home");
+//               } else if (ecopercentAuthResult.status === 404) {
+//                 console.log("회원가입 하러 가기");
+//                 navigate("/signup");
+//               }
+//             })
+//             .catch((e) => {
+//               console.log("ecopercent kakao auth erro", e);
+//             });
+//         });
+//       console.log("gogo!!");
+//     }
+//   }, [code]);
+
+//   return (
+//     <S.LoginButton onClick={kakaoLogin}>
+//       <S.LogoImg src="/img/kakaoLogo.png" alt="kakao login" />
+//     </S.LoginButton>
+//   );
+// }

--- a/src/Components/Login/SocialLogin.jsx
+++ b/src/Components/Login/SocialLogin.jsx
@@ -11,8 +11,6 @@ export default function SocialLogin() {
     if (location.pathname.split("/")[2] === "kakao") {
       const params = new URLSearchParams(location.search);
       if (params.has("code")) {
-        console.log("카카오 인가 코드 받았어!");
-        console.log(params.get("code"));
         getKakaoToken({ authCode: params.get("code"), navigate });
       }
     }

--- a/src/Components/Login/kakaoLogin.jsx
+++ b/src/Components/Login/kakaoLogin.jsx
@@ -34,7 +34,7 @@ async function postKakaoToken({ kakaoAccessToken, navigate }) {
     }
   } catch (err) {
     if (err.response.status === 404) {
-      cookie.save("email", err.response.data, { path: "/signup" });
+      cookie.save("email", err.response.data.email, { path: "/signup" });
       navigate("/signup");
     } else {
       // 서버 안될 때

--- a/src/Components/Login/kakaoLogin.jsx
+++ b/src/Components/Login/kakaoLogin.jsx
@@ -24,11 +24,15 @@ export async function kakaoLogin() {
 
 async function postKakaoToken({ kakaoAccessToken, navigate }) {
   try {
-    const response = await axios.post("/login/oauth2/kakao", {
-      headers: {
-        Authorization: `Bearer ${kakaoAccessToken}`,
-      },
-    });
+    const response = await axios.post(
+      "/login/oauth2/kakao",
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${kakaoAccessToken}`,
+        },
+      }
+    );
     if (response.status === 200) {
       navigate("/home");
     }

--- a/src/Components/Login/kakaoLogin.jsx
+++ b/src/Components/Login/kakaoLogin.jsx
@@ -24,7 +24,7 @@ export async function kakaoLogin() {
 
 async function postKakaoToken({ kakaoAccessToken, navigate }) {
   try {
-    const response = await axios.get("/login/oauth2/kakao", {
+    const response = await axios.post("/login/oauth2/kakao", {
       headers: {
         Authorization: `Bearer ${kakaoAccessToken}`,
       },

--- a/src/Components/Login/kakaoLogin.jsx
+++ b/src/Components/Login/kakaoLogin.jsx
@@ -1,6 +1,7 @@
+import axios from "axios";
 import { scriptLoad } from "../../Utils/script";
 
-export default async function kakaoLogin() {
+export async function kakaoLogin() {
   const name = "KAKAO";
   const src = "https://t1.kakaocdn.net/kakao_js_sdk/2.1.0/kakao.min.js";
   const crossOrigin = "anonymous";
@@ -17,4 +18,57 @@ export default async function kakaoLogin() {
   }
 
   return null;
+}
+
+async function postKakaoToken({ kakaoAccessToken, navigate }) {
+  try {
+    console.log("에코 서버에 카카오 액세스 토큰 보내기!");
+    const response = await axios.get("/login/oauth2/kakao", {
+      headers: {
+        Authorization: `Bearer ${kakaoAccessToken}`,
+      },
+    });
+    if (response.status === 200) {
+      console.log("유저 있음! 로그인 시켜주자");
+    }
+  } catch (err) {
+    if (err.response.status === 404) {
+      console.log(err);
+      console.log("유저 없음! 회원가입 시켜주자");
+    } else navigate("/");
+  }
+}
+
+export async function getKakaoToken({ authCode, navigate }) {
+  try {
+    const response = await axios.post(
+      "https://kauth.kakao.com/oauth/token",
+      {
+        // data
+        grant_type: "authorization_code",
+        client_id: `${process.env.REACT_APP_KAKAO_JS_KEY}`,
+        redirect_uri: `${process.env.REACT_APP_KAKAO_REDIRECT_URI}`,
+        code: `${authCode}`,
+      },
+      {
+        // config
+        headers: {
+          "Content-type": "application/x-www-form-urlencoded;charset=utf-8",
+        },
+      }
+    );
+    if (response.status === 200) {
+      console.log("인가 코드 주고 받아온거!");
+      console.log(response.data);
+      postKakaoToken({
+        kakaoAccessToken: response.data.access_token,
+        navigate,
+      });
+    } else {
+      navigate("/");
+    }
+  } catch (err) {
+    console.log(err);
+    navigate("/");
+  }
 }

--- a/src/Components/Login/kakaoLogin.jsx
+++ b/src/Components/Login/kakaoLogin.jsx
@@ -35,6 +35,7 @@ async function postKakaoToken({ kakaoAccessToken, navigate }) {
   } catch (err) {
     if (err.response.status === 404) {
       cookie.save("email", err.response.data.email, { path: "/" });
+      cookie.save("oauth_provider", "kakao", { path: "/" });
       navigate("/signup");
     } else {
       // 서버 안될 때

--- a/src/Components/Login/kakaoLogin.jsx
+++ b/src/Components/Login/kakaoLogin.jsx
@@ -34,7 +34,7 @@ async function postKakaoToken({ kakaoAccessToken, navigate }) {
     }
   } catch (err) {
     if (err.response.status === 404) {
-      cookie.save("email", err.response.data.email, { path: "/signup" });
+      cookie.save("email", err.response.data.email, { path: "/" });
       navigate("/signup");
     } else {
       // 서버 안될 때

--- a/src/Components/Modal/style.jsx
+++ b/src/Components/Modal/style.jsx
@@ -63,6 +63,10 @@ export const Btn = styled.button`
     if (props.warning) return btn.pink;
     return btn.normal;
   }}
+
+  :hover {
+    opacity: 0.7;
+  }
 `;
 
 export const CreateModal = styled.div`

--- a/src/Components/SignUp/Form/style.jsx
+++ b/src/Components/SignUp/Form/style.jsx
@@ -101,7 +101,15 @@ export const Btn = styled.button`
     if (props.warning) return button.pink;
     if (props.disabled) return button.disabled;
     return button.normal;
-  }}}
+  }}
+
+  ${(props) => {
+    if (!props.disabled)
+      return `:hover {
+    opacity: 0.7;
+  }`;
+    return null;
+  }}
 `;
 
 /*

--- a/src/Components/SignUp/SignUp.jsx
+++ b/src/Components/SignUp/SignUp.jsx
@@ -47,7 +47,7 @@ export default function SignUp() {
     mutationFn: postUser,
     onSuccess: () => {
       cookie.remove("signup");
-      cookie.remove("email");
+      cookie.remove("email", { path: "/signup" });
     },
   });
 
@@ -82,6 +82,7 @@ export default function SignUp() {
           onConfirm={() => {
             setModalIsOpen(false);
             cookie.remove("signup");
+            cookie.remove("email");
             navigate("/");
           }}
         />

--- a/src/Components/SignUp/SignUp.jsx
+++ b/src/Components/SignUp/SignUp.jsx
@@ -26,28 +26,34 @@ export default function SignUp() {
 
   // TODO: 페이지 이탈 확인 -> 아이템 context, 유저 쿠키 삭제
   useEffect(() => {
-    if (cookie.load("signup")) setUserInput(cookie.load("signup"));
+    if (cookie.load("signup")) {
+      setUserInput(cookie.load("signup"));
+      cookie.remove("signup");
+    }
     if (cookie.load("email"))
-      setUserInput({ ...userInput, email: cookie.load("email") });
-    if (cookie.load("validCheck"))
+      setUserInput((oldInput) => {
+        return { ...oldInput, email: cookie.load("email") };
+      });
+    if (cookie.load("validCheck")) {
       setNicknameIsValid(cookie.load("validCheck"));
-    if (cookie.load("warning")) setWarningText(cookie.load("warning"));
+      cookie.remove("validCheck");
+    }
+    if (cookie.load("warning")) {
+      setWarningText(cookie.load("warning"));
+      cookie.remove("warning");
+    }
   }, []);
 
   const saveUserInput = () => {
-    cookie.save("signup", userInput, { maxAge: 60 * 30 });
-    if (nicknameIsValid)
-      cookie.save("validCheck", nicknameIsValid, {
-        maxAge: 60 * 30,
-      });
-    if (warningText) cookie.save("warning", warningText, { maxAge: 60 * 30 });
+    cookie.save("signup", userInput);
+    if (nicknameIsValid) cookie.save("validCheck", nicknameIsValid);
+    if (warningText) cookie.save("warning", warningText);
   };
 
   const signUpMutation = useMutation({
     mutationFn: postUser,
     onSuccess: () => {
-      cookie.remove("signup");
-      cookie.remove("email", { path: "/signup" });
+      cookie.remove("email", { path: "/" });
     },
   });
 

--- a/src/Components/SignUp/SignUp.jsx
+++ b/src/Components/SignUp/SignUp.jsx
@@ -54,6 +54,7 @@ export default function SignUp() {
     mutationFn: postUser,
     onSuccess: () => {
       cookie.remove("email", { path: "/" });
+      cookie.remove("oauth_provider", { path: "/" });
     },
   });
 
@@ -61,15 +62,24 @@ export default function SignUp() {
   // const { state } = useContext(SignUpItemContext);
 
   const handleSubmit = () => {
-    const signUpForm = { ...userInput };
+    let signUpForm = {
+      ...userInput,
+      oAuthProvider: cookie.load("oauth_provider"),
+    };
     if (signUpForm.nickname.length === 0)
       return setWarningText("닉네임을 입력하세요.");
     if (!nicknameIsValid)
       return setWarningText("닉네임 중복확인을 완료해주세요.");
 
+    signUpForm = {
+      ...signUpForm,
+      oAuthProvider: cookie.load("oauth_provider"),
+    };
+
     // TODO: api 업데이트 되면 아이템 폼에 넣기
     // if (state.tumbler)
     // if (state.ecobag)
+
     signUpMutation.mutate(signUpForm);
     return navigate("/welcome", { state: true });
   };
@@ -89,6 +99,7 @@ export default function SignUp() {
             setModalIsOpen(false);
             cookie.remove("signup");
             cookie.remove("email");
+            cookie.remove("oauth_provider");
             navigate("/");
           }}
         />

--- a/src/Components/SignUp/SignUp.jsx
+++ b/src/Components/SignUp/SignUp.jsx
@@ -47,7 +47,7 @@ export default function SignUp() {
     mutationFn: postUser,
     onSuccess: () => {
       cookie.remove("signup");
-      // TODO: 응답의 토큰 처리
+      cookie.remove("email");
     },
   });
 
@@ -65,7 +65,6 @@ export default function SignUp() {
     // if (state.tumbler)
     // if (state.ecobag)
     signUpMutation.mutate(signUpForm);
-    // TODO: 가입 완료 페이지 or 모달 구현
     return navigate("/welcome", { state: true });
   };
 

--- a/src/Components/SignUp/style.jsx
+++ b/src/Components/SignUp/style.jsx
@@ -52,7 +52,15 @@ export const Btn = styled.button`
     if (props.warning) return button.pink;
     if (props.disabled) return button.disabled;
     return button.normal;
-  }}}
+  }}
+
+  ${(props) => {
+    if (!props.disabled)
+      return `:hover {
+    opacity: 0.7;
+  }`;
+    return null;
+  }}
 `;
 
 /*
@@ -89,4 +97,8 @@ export const GoHomeBtn = styled.button`
   ${font.normalSubheadline}
   height: 40px;
   width: 100px;
+
+  :hover {
+    background: ${basicGreen};
+  }
 `;

--- a/src/Layouts/App/App.jsx
+++ b/src/Layouts/App/App.jsx
@@ -43,7 +43,7 @@ function App() {
         <BrowserRouter>
           <Routes>
             <Route path="/" element={<Login />} />
-            <Route path="/login" element={<Login />} />
+            <Route path="/login/*" element={<Login />} />
             <Route path="/signup" element={<SignUp />} />
             <Route path="/welcome" element={<Welcome />} />
             <Route path="/:page" element={<Main />} />

--- a/src/Layouts/Login/Login.jsx
+++ b/src/Layouts/Login/Login.jsx
@@ -25,9 +25,6 @@ const Login = () => {
       dispatch({
         type: "ecobagDelete",
       });
-    cookie.remove("signup");
-    cookie.remove("validCheck");
-    cookie.remove("warning");
   });
 
   return (


### PR DESCRIPTION
## 개요
- 카카오 간편 로그인 구현

## 작업사항
- 변경된 로직으로 업데이트
- 서버에서 토큰 받아서 로그인/회원가입 리다이렉트

## 변경로직
- 기존: 카카오 authorize() 이후 서버에서 핸들링
- 현재: 프론트에서 카카오로부터 엑세스토큰 받아와서 서버에게 전달하고 eco 서버의 토큰으로 교환 받기

## 코멘트
- 애써주신 덕분에 변경된 로직도 금방 끝났다요! 신난다!!

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->