### PR TITLE
feat: userid 로컬스토리지->쿠키 migration

### DIFF
--- a/src/Components/Home/Profile/Profile.jsx
+++ b/src/Components/Home/Profile/Profile.jsx
@@ -1,10 +1,10 @@
 import React, { useState } from "react";
 import ProfileViewer from "./ProfileViewer/ProfileViewer";
 import ProfileEditor from "./ProfileEditor/ProfileEditor";
-import { getLogin } from "../../../Layouts/Login/Login";
+import { getUserId } from "../../../Layouts/Login/Login";
 
 export default function Profile() {
-  const userId = getLogin();
+  const userId = getUserId();
   const [isEditing, setIsEditing] = useState(false);
 
   if (isEditing)

--- a/src/Components/Home/TitleItems/TitleItemBox.jsx
+++ b/src/Components/Home/TitleItems/TitleItemBox.jsx
@@ -5,10 +5,10 @@ import ConvertButtons from "./ConvertBtn/ConvertButtons";
 import TitleItem from "./TitleItem/TitleItem";
 import NoTitleItem from "./TitleItem/NoTitleItem";
 import * as S from "./style";
-import { getLogin } from "../../../Layouts/Login/Login";
+import { getUserId } from "../../../Layouts/Login/Login";
 
 export default function TitleItemBox() {
-  const userId = getLogin();
+  const userId = getUserId();
 
   const titleTumblerQuery = useQuery({
     queryKey: ["title", "tumbler", Number(userId)],

--- a/src/Layouts/Login/Login.jsx
+++ b/src/Layouts/Login/Login.jsx
@@ -1,19 +1,14 @@
-import React, { useContext, useEffect, useRef } from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useContext, useEffect } from "react";
 import cookie from "react-cookies";
 import SocialLogin from "../../Components/Login/SocialLogin";
 import * as S from "./style";
 import SignUpItemContext from "../../hooks/SignUpItemContext";
 
-export function getLogin() {
-  const userid = cookie.load("userid");
-  if (userid) return userid;
-  return localStorage.getItem("userId");
+export function getUserId() {
+  return cookie.load("userid");
 }
 
 const Login = () => {
-  const navigate = useNavigate();
-  const userId = useRef();
   const { state, dispatch } = useContext(SignUpItemContext);
 
   useEffect(() => {
@@ -35,25 +30,6 @@ const Login = () => {
         <S.ContinueWith>Continue With</S.ContinueWith>
         {/* 소셜 로그인 버튼들 들어갈 곳 */}
         <SocialLogin />
-        <form
-          onSubmit={(e) => {
-            e.preventDefault();
-            localStorage.setItem("userId", userId.current.value);
-            navigate("/home");
-          }}
-        >
-          <input type="number" ref={userId} />
-          <button type="submit">로그인</button>
-          {/* 임시 버튼. OAuth 이후 연결할 페이지 */}
-          <button
-            type="button"
-            onClick={() => {
-              return navigate("/signup");
-            }}
-          >
-            회원가입
-          </button>
-        </form>
         <S.Line />
       </S.LoginBox>
       <S.SloganSpan>에코퍼센트 슬로건 한줄.</S.SloganSpan>

--- a/src/Pages/Item/Item.jsx
+++ b/src/Pages/Item/Item.jsx
@@ -1,12 +1,12 @@
 import React, { useState } from "react";
-import { getLogin } from "../../Layouts/Login/Login";
+import { getUserId } from "../../Layouts/Login/Login";
 import AllInfo from "../../Components/Item/Info/AllInfo";
 import EachInfo from "../../Components/Item/Info/EachInfo";
 import ItemListBox from "../../Components/Item/List/ItemListBox";
 import * as S from "./style";
 
 const Item = () => {
-  const userId = getLogin();
+  const userId = getUserId();
   const [infoItemId, setInfoItemId] = useState(0);
   const [infoItemCategory, setInfoItemCategory] = useState("tumbler");
 

--- a/src/Pages/ItemModification/ItemAdd/ItemAdd.jsx
+++ b/src/Pages/ItemModification/ItemAdd/ItemAdd.jsx
@@ -7,6 +7,7 @@ import ItemAddHead from "./ItemAddHead";
 import { ItemEditBorder, ItemEditWrap } from "../style";
 import { postItem } from "../../../Api/item";
 import SignUpItemContext from "../../../hooks/SignUpItemContext";
+import { getUserId } from "../../../Layouts/Login/Login";
 
 const ItemAdd = () => {
   const item = useLocation().state;
@@ -39,17 +40,14 @@ const ItemAdd = () => {
   const itemAddMutation = useMutation({
     mutationFn: postItem,
     onSuccess: () => {
-      queryClient.refetchQueries([
-        `${item.category}s`,
-        Number(localStorage.getItem("userId")),
-      ]);
+      queryClient.refetchQueries([`${item.category}s`, Number(getUserId())]);
     },
   });
 
   const addItemOnAuth = useCallback(
     (input) => {
       itemAddMutation.mutate({
-        itemUserId: Number(localStorage.getItem("userId")),
+        itemUserId: Number(getUserId()),
         itemImage: "이미지피커에서가져올거얏",
         itemNickname: input.nickname,
         itemCategory: item.category,

--- a/src/Pages/ItemModification/ItemEdit/DeleteItemModal.jsx
+++ b/src/Pages/ItemModification/ItemEdit/DeleteItemModal.jsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import Modal from "../../../Components/Modal/Modal";
 import { deleteItem } from "../../../Api/item";
+import { getUserId } from "../../../Layouts/Login/Login";
 import * as S from "../style";
 
 const DeleteItemModal = ({
@@ -17,15 +18,8 @@ const DeleteItemModal = ({
     mutationFn: deleteItem,
     onSuccess: () => {
       queryClient.refetchQueries(["item", Number(item.id)]);
-      queryClient.refetchQueries([
-        `${item.category}s`,
-        Number(localStorage.getItem("userId")),
-      ]);
-      queryClient.refetchQueries([
-        "title",
-        item.category,
-        Number(localStorage.getItem("userId")),
-      ]);
+      queryClient.refetchQueries([`${item.category}s`, Number(getUserId())]);
+      queryClient.refetchQueries(["title", item.category, Number(getUserId())]);
     },
   });
   const onDeleteItem = useCallback((e) => {

--- a/src/Pages/ItemModification/ItemEdit/ItemEdit.jsx
+++ b/src/Pages/ItemModification/ItemEdit/ItemEdit.jsx
@@ -8,6 +8,7 @@ import ItemEditDetail from "./ItemEditDetail";
 import ItemEditHead from "./ItemEditHead";
 import { ItemEditBorder, ItemEditWrap } from "../style";
 import SignUpItemContext from "../../../hooks/SignUpItemContext";
+import { getUserId } from "../../../Layouts/Login/Login";
 
 const ItemEdit = () => {
   const item = useLocation().state;
@@ -51,15 +52,8 @@ const ItemEdit = () => {
     mutationFn: patchItem,
     onSuccess: () => {
       queryClient.refetchQueries(["item", Number(item.id)]);
-      queryClient.refetchQueries([
-        `${item.category}s`,
-        Number(localStorage.getItem("userId")),
-      ]);
-      queryClient.refetchQueries([
-        "title",
-        item.category,
-        Number(localStorage.getItem("userId")),
-      ]);
+      queryClient.refetchQueries([`${item.category}s`, Number(getUserId())]);
+      queryClient.refetchQueries(["title", item.category, Number(getUserId())]);
     },
   });
 

--- a/src/Pages/Setting/Setting.jsx
+++ b/src/Pages/Setting/Setting.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { cookie } from "react-cookie";
 import * as S from "./style";
 import AccountInfo from "./AccountInfo";
 import Error from "../../Layouts/Error/Error";
@@ -92,7 +93,8 @@ const Setting = () => {
       <hr />
       <S.Logout
         onClick={() => {
-          localStorage.removeItem("userId");
+          cookie.remove("userid");
+          cookie.remove("refresh");
           navigate("/");
         }}
       >

--- a/src/Pages/Setting/Setting.jsx
+++ b/src/Pages/Setting/Setting.jsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { cookie } from "react-cookie";
+import cookie from "react-cookies";
 import * as S from "./style";
 import AccountInfo from "./AccountInfo";
 import Error from "../../Layouts/Error/Error";
@@ -94,7 +94,6 @@ const Setting = () => {
       <S.Logout
         onClick={() => {
           cookie.remove("userid");
-          cookie.remove("refresh");
           navigate("/");
         }}
       >


### PR DESCRIPTION
## 개요
- userid 로컬스토리지->쿠키 migration

## 작업사항
- 로컬스토리지에서 불러오던 userid 쿠키에서 가져오기로 변경
- userid 로그인 폼/회원가입 페이지 링크 삭제

## 변경로직
- 이제 무조건 소셜 로그인만 가능!

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->