### PR TITLE
Ecopercent 429 닉네임 중복 연동

### DIFF
--- a/src/Api/user.jsx
+++ b/src/Api/user.jsx
@@ -23,3 +23,13 @@ export function patchUser({ id, nick, msg, img }) {
       return res.data;
     });
 }
+export function nicknameCheck(nickname) {
+  return axios
+    .get(`/nicknames/${nickname}`)
+    .then(() => {
+      return 200;
+    })
+    .catch((err) => {
+      return err.response.status;
+    });
+}

--- a/src/Components/SignUp/Form/SignUpUser.jsx
+++ b/src/Components/SignUp/Form/SignUpUser.jsx
@@ -25,6 +25,9 @@ export default function SignUpUser({
         setNicknameIsValid(true);
         setWarningText(null);
         if (nicknameIsValid) setNicknameIsValid(false);
+      } else {
+        // 닉네임 정책 제대로 정해야할듯합니다. ex) 빈공백, /조합, \ 조합  # 등
+        alert("닉네임을 확인해주세요.");
       }
     } catch (err) {
       console.log("server error");

--- a/src/Components/SignUp/Form/SignUpUser.jsx
+++ b/src/Components/SignUp/Form/SignUpUser.jsx
@@ -18,7 +18,7 @@ export default function SignUpUser({
       if (validateResult === 200) {
         // 이미 있는 닉네임일때 인풋값을 지울까 말까
         // 경고창 대신 모달로 띄워줄까 말까
-        alert("이미 사용 중인 닉네임입니다.");
+        alert("이미 사용 중인 닉네임입니다.\n다른 닉네임을 사용해 주세요.");
         setWarningText("다른 닉네임을 사용해 주세요.");
       } else if (validateResult === 404) {
         // 성공했을때 성공한 닉네임을 사용할지 말지 모달로 선택하게 할까 말까

--- a/src/Components/SignUp/Form/SignUpUser.jsx
+++ b/src/Components/SignUp/Form/SignUpUser.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import * as S from "./style";
+import { nicknameCheck } from "../../../Api/user";
 
 export default function SignUpUser({
   userInput,
@@ -9,12 +10,25 @@ export default function SignUpUser({
   warningText,
   setWarningText,
 }) {
-  const validateNickname = () => {
+  const validateNickname = async (e) => {
     // TODO: 닉네임 중복확인 api 요청 하고 결과에 따른 로직 추가
-    setNicknameIsValid(true);
-    setWarningText(null);
-    if (nicknameIsValid) setNicknameIsValid(false);
-    alert("중복 확인 API 호출");
+    e.preventDefault();
+    try {
+      const validateResult = await nicknameCheck(userInput.nickname);
+      if (validateResult === 200) {
+        // 이미 있는 닉네임일때 인풋값을 지울까 말까
+        // 경고창 대신 모달로 띄워줄까 말까
+        alert("이미 사용 중인 닉네임입니다.");
+        setWarningText("다른 닉네임을 사용해 주세요.");
+      } else if (validateResult === 404) {
+        // 성공했을때 성공한 닉네임을 사용할지 말지 모달로 선택하게 할까 말까
+        setNicknameIsValid(true);
+        setWarningText(null);
+        if (nicknameIsValid) setNicknameIsValid(false);
+      }
+    } catch (err) {
+      console.log("server error");
+    }
   };
 
   const lengthSliceInKorean = (e) => {


### PR DESCRIPTION
## 개요
- 닉네임 중복 연동작업

## 작업사항
- 간단하게 닉네임 중복 확인 api 호출 및 비동기 처리로 상태코드 받아와서 분기 및 처리
- 200일 경우 이미 존재하는 닉네임으로 다른 닉네임 사용을 위한 경고창, 경고문구 변경
- 404일 경우 사용 가능한 닉네임으로 기존 동작 그대로 작동하게 함

여러가지 옵션이 있어서 논의 한번 해보면 좋을 것 같아용 일단 PR 올립니다!