### PR TITLE
feat: 글자수제한  점검 및 변경

### DIFF
--- a/src/Components/Home/Profile/ProfileEditor/ProfileText.jsx
+++ b/src/Components/Home/Profile/ProfileEditor/ProfileText.jsx
@@ -9,16 +9,16 @@ export default function ProfileText({ user, setUser, isMobile }) {
         onChange={(e) => {
           setUser({ ...user, nickname: e.target.value });
         }}
-        rows="1"
-        maxLength="8"
+        rows={1}
+        maxLength={8}
       />
       <S.ProfileTextarea
         value={user.profileMessage}
         onChange={(e) => {
           setUser({ ...user, profileMessage: e.target.value });
         }}
-        rows={isMobile ? "4" : "3"}
-        maxLength="70"
+        rows={isMobile ? 4 : 3}
+        maxLength={35}
       />
     </S.ProfileTextForm>
   );

--- a/src/Pages/ItemModification/ItemAdd/ItemAddDetail.jsx
+++ b/src/Pages/ItemModification/ItemAdd/ItemAddDetail.jsx
@@ -44,7 +44,7 @@ const ItemAddDetail = ({ submitCallback }) => {
             maxLength={12}
           />
           <S.Span>타입</S.Span>
-          <S.Input value={type} onChange={onType} />
+          <S.Input value={type} onChange={onType} maxLength={12} />
           <S.Span>목표횟수</S.Span>
           <S.Input
             style={{ backgroundColor: "lightgray" }}
@@ -53,7 +53,18 @@ const ItemAddDetail = ({ submitCallback }) => {
             readOnly
           />
           <S.Span>구입가</S.Span>
-          <S.Input value={price} onChange={onPrice} type="number" />
+          <S.Input
+            value={price}
+            onChange={(e) => {
+              e.preventDefault();
+              if (e.target.value.length > e.target.maxLength)
+                e.target.value = e.target.value.slice(0, e.target.maxLength);
+              e.target.value = Number(e.target.value);
+              onPrice(e);
+            }}
+            maxLength={12}
+            type="number"
+          />
           <S.Span>구입일</S.Span>
           <S.Input value={purchaseDate} onChange={onPurchaseData} type="date" />
         </S.FormInnerWrapper>

--- a/src/Pages/ItemModification/ItemEdit/ItemEditDetail.jsx
+++ b/src/Pages/ItemModification/ItemEdit/ItemEditDetail.jsx
@@ -46,7 +46,7 @@ const ItemEditDetail = ({ itemDetail, editCallback }) => {
             placeholder={itemDetail.brand}
           />
           <S.Span>타입</S.Span>
-          <S.Input value={type} onChange={onType} />
+          <S.Input value={type} onChange={onType} maxLength={12} />
           <S.Span>목표횟수</S.Span>
           <S.Input
             style={{ backgroundColor: "lightgray" }}
@@ -58,9 +58,15 @@ const ItemEditDetail = ({ itemDetail, editCallback }) => {
           <S.Span>구입가</S.Span>
           <S.Input
             value={price}
-            onChange={onPrice}
+            onChange={(e) => {
+              e.preventDefault();
+              if (e.target.value.length > e.target.maxLength)
+                e.target.value = e.target.value.slice(0, e.target.maxLength);
+              e.target.value = Number(e.target.value);
+              onPrice(e);
+            }}
+            maxLength={12}
             type="number"
-            placeholder={itemDetail.price}
           />
           <S.Span>구입일</S.Span>
           <S.Input


### PR DESCRIPTION
## 개요
- 글자수 제한  점검 및 변경

## 작업사항
- 프로필 변경 70자에서 35자로 통일
- 아이템 추가/변경에서 타입 12자, 구입가 숫자로 캐스팅+12자 제한