### PR TITLE
refact: 간편로그인 구현부 리팩토링

### DIFF
--- a/src/Components/Login/SocialLogin.jsx
+++ b/src/Components/Login/SocialLogin.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { kakaoLogin, getKakaoToken } from "./kakaoLogin";
+import { getKakaoAuthCode, KakaoLoginButton } from "./kakaoLogin";
 import AppleLoginButton from "./appleLogin";
 import * as S from "./style";
 
@@ -9,22 +9,14 @@ export default function SocialLogin() {
   const navigate = useNavigate();
 
   useEffect(() => {
-    if (location.pathname.split("/")[2] === "kakao") {
-      const params = new URLSearchParams(location.search);
-      if (params.has("code")) {
-        getKakaoToken({ authCode: params.get("code"), navigate });
-      }
-    }
-  }, []);
+    if (location.pathname.split("/")[2] === "kakao")
+      getKakaoAuthCode({ searchParams: location.search, navigate });
+  }, [location]);
 
   return (
-    <>
-      <S.LoginButton onClick={kakaoLogin}>
-        <S.LogoImg src="/img/kakaoLogo.png" alt="kakao login" />
-      </S.LoginButton>
-      <S.LoginButton>
-        <AppleLoginButton />
-      </S.LoginButton>
-    </>
+    <S.ButtonBox>
+      <KakaoLoginButton />
+      <AppleLoginButton />
+    </S.ButtonBox>
   );
 }

--- a/src/Components/Login/kakaoLogin.jsx
+++ b/src/Components/Login/kakaoLogin.jsx
@@ -1,18 +1,18 @@
+import React from "react";
 import axios from "axios";
 import cookie from "react-cookies";
 import { scriptLoad } from "../../Utils/script";
+import { LogoImg } from "./style";
 
 export async function kakaoLogin() {
-  const name = "KAKAO";
   const src = "https://t1.kakaocdn.net/kakao_js_sdk/2.1.0/kakao.min.js";
-  const crossOrigin = "anonymous";
 
   try {
-    await scriptLoad({ name, src, crossOrigin });
+    await scriptLoad({ name: "KAKAO", src, crossOrigin: "anonymous" });
     if (!window.Kakao.isInitialized())
       window.Kakao.init(process.env.REACT_APP_KAKAO_JS_KEY);
     window.Kakao.Auth.authorize({
-      redirectUri: process.env[`REACT_APP_${name}_REDIRECT_URI`],
+      redirectUri: process.env.REACT_APP_KAKAO_REDIRECT_URI,
     });
   } catch (error) {
     // 카카오 서버 안될 때
@@ -76,4 +76,17 @@ export async function getKakaoToken({ authCode, navigate }) {
     // 유저가 취소했을 때
     navigate("/");
   }
+}
+
+export async function getKakaoAuthCode({ searchParams, navigate }) {
+  const params = new URLSearchParams(searchParams);
+  if (params.has("code")) {
+    await getKakaoToken({ authCode: params.get("code"), navigate });
+  }
+}
+
+export function KakaoLoginButton() {
+  return (
+    <LogoImg onClick={kakaoLogin} src="/img/kakaoLogo.png" alt="kakao login" />
+  );
 }

--- a/src/Components/Login/style.js
+++ b/src/Components/Login/style.js
@@ -1,20 +1,13 @@
 import styled from "@emotion/styled";
 
-export const LoginButton = styled.button`
-  position: relative;
-  width: 60px;
-  height: 60px;
-
-  border: none;
-  border-radius: 100%;
-  background: rgba(0, 0, 0, 0);
-  cursor: pointer;
+export const ButtonBox = styled.div`
+  display: flex;
+  gap: 10px;
 `;
 
 export const LogoImg = styled.img`
-  position: absolute;
-  top: 0;
-  left: 0;
   width: 60px;
   height: 60px;
+  border-radius: 100%;
+  cursor: pointer;
 `;

--- a/src/Layouts/Login/Login.jsx
+++ b/src/Layouts/Login/Login.jsx
@@ -23,7 +23,6 @@ const Login = () => {
       <S.LoginBox>
         <S.Line />
         <S.ContinueWith>Continue With</S.ContinueWith>
-        {/* 소셜 로그인 버튼들 들어갈 곳 */}
         <SocialLogin />
         <S.Line />
       </S.LoginBox>


### PR DESCRIPTION
## 개요
- 간편로그인 구현부 리팩토링

## 작업사항
- 재사용성 고려해서 짠 부분 최대한 삭제
  - script 파일도 그런 의미지만 일단 두는걸로~!
- 로그인 버튼 가로 배치
- 불필요한 스타일 코드 삭제
- 애플로그인과 추상화 단계 통일하기!

## 코멘트
오늘 추상화라는걸 새로 알아서 PR에 적어보았다 캬캬


<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->