### PR TITLE
feat: 아이템 추가/수정 후 리스트에서 포커싱 유지

### DIFF
--- a/src/Api/item.jsx
+++ b/src/Api/item.jsx
@@ -40,7 +40,7 @@ export function deleteItem(itemId) {
 }
 
 export function patchUsageCountUp(itemId) {
-  return axios.patch(`/items/${itemId}/up`).then((res) => {
+  return axios.patch(`/items/${itemId}/usage-count`).then((res) => {
     return res.data;
   });
 }

--- a/src/Components/Home/Profile/ProfileEditor/ProfileEditor.jsx
+++ b/src/Components/Home/Profile/ProfileEditor/ProfileEditor.jsx
@@ -47,7 +47,6 @@ export default function ProfileEditor({ setIsEditing }) {
       typeof userImgFile === "object" ? userImgFile : null
     );
     profileEditMutation.mutate(formData);
-    return profileEditMutation.mutateAsync;
   }
 
   return (

--- a/src/Components/Home/TitleItems/TitleItem/ItmeImageStroke.jsx
+++ b/src/Components/Home/TitleItems/TitleItem/ItmeImageStroke.jsx
@@ -71,8 +71,9 @@ const ItmeImageStroke = ({ itemInfo }) => {
     onSuccess: () => {
       const newItemInfo = { ...itemInfo };
       newItemInfo.currentUsageCount += 1;
-      queryClient.setQueryData(["title", `${itemInfo.category}`], newItemInfo);
-      queryClient.invalidateQueries(["title", `${itemInfo.category}`]);
+      queryClient.setQueryData(["title", itemInfo.category], newItemInfo);
+      queryClient.invalidateQueries(["title", itemInfo.category]);
+      queryClient.invalidateQueries([itemInfo.category, "list"]);
     },
   });
   const increaseCount = useCallback(() => {

--- a/src/Components/Item/Info/AllInfo.jsx
+++ b/src/Components/Item/Info/AllInfo.jsx
@@ -3,61 +3,68 @@ import { useQuery } from "@tanstack/react-query";
 import { getItemList } from "../../../Api/item";
 import * as S from "./style";
 
-export default function AllInfo() {
-  const tumblersQuery = useQuery({
-    queryKey: ["tumbler", "list"],
+export default function AllInfo({ category }) {
+  const total = {
+    usageCnt: 0,
+    goalUsageCnt: 0,
+    usagePercent: 0,
+    totalCnt: 0,
+    achivedCnt: 0,
+    achivedPercent: 0,
+  };
+  const itemsQuery = useQuery({
+    queryKey: [category, "list"],
     queryFn: () => {
-      return getItemList("tumbler");
+      return getItemList(category);
     },
   });
 
-  const ecobagsQuery = useQuery({
-    queryKey: ["ecobag", "list"],
-    queryFn: () => {
-      return getItemList("ecobag");
-    },
-  });
-
-  const achivedCnt = { tumbler: 0, ecobag: 0 };
-  if (tumblersQuery.isSuccess) {
-    achivedCnt.tumbler = tumblersQuery.data.filter((tumbler) => {
-      return tumbler.usageCount >= tumbler.goalUsageCount;
+  if (itemsQuery.isLoading || itemsQuery.isError) return null;
+  if (itemsQuery.isSuccess) {
+    total.achivedCnt = itemsQuery.data.filter((item) => {
+      total.usageCnt += Number(item.currentUsageCount);
+      total.goalUsageCnt += Number(item.goalUsageCount);
+      return item.usageCount >= item.goalUsageCount;
     }).length;
-  }
-  if (ecobagsQuery.isSuccess) {
-    achivedCnt.ecobag = ecobagsQuery.data.filter((ecobag) => {
-      return ecobag.usageCount >= ecobag.goalUsageCount;
-    }).length;
+    total.usagePercent = total.usageCnt / total.goalUsageCnt;
+    total.totalCnt = itemsQuery.data.length;
+    total.achivedPercent = total.achivedCnt / total.totalCnt;
   }
 
   return (
     <S.InfoContainer>
-      <S.InfoHeaderDiv>나의 아이템</S.InfoHeaderDiv>
+      <S.InfoHeaderDiv>
+        나의 {category === "tumbler" ? "텀블러" : "에코백"}
+      </S.InfoHeaderDiv>
       <S.InfoContentsDiv>
         <S.ContentPart>
           <S.InfoLabel>
-            텀블러
+            보유 아이템수
             <br />
-            달성개수
+            달성 아이템수
             <br />
+            달성 개수 퍼센트
             <br />
           </S.InfoLabel>
           <S.InfoValue>
-            {tumblersQuery.data ? tumblersQuery.data.length : 0}개<br />
-            {achivedCnt.tumbler}개<br />
+            {itemsQuery.data?.length}개<br />
+            {total.achivedCnt}개<br />
+            {total.achivedPercent}%
           </S.InfoValue>
         </S.ContentPart>
         <S.ContentPart>
           <S.InfoLabel>
-            에코백
+            총 사용횟수
             <br />
-            달성개수
+            총 목표횟수
             <br />
+            사용 횟수 퍼센트
             <br />
           </S.InfoLabel>
           <S.InfoValue>
-            {ecobagsQuery.data ? ecobagsQuery.data.length : 0}개<br />
-            {achivedCnt.ecobag}개<br />
+            {total.usageCnt}회<br />
+            {total.goalUsageCnt}회<br />
+            {total.usagePercent}%<br />
           </S.InfoValue>
         </S.ContentPart>
       </S.InfoContentsDiv>

--- a/src/Components/Item/Info/AllInfo.jsx
+++ b/src/Components/Item/Info/AllInfo.jsx
@@ -26,9 +26,9 @@ export default function AllInfo({ category }) {
       total.goalUsageCnt += Number(item.goalUsageCount);
       return item.usageCount >= item.goalUsageCount;
     }).length;
-    total.usagePercent = total.usageCnt / total.goalUsageCnt;
+    total.usagePercent = Math.round(total.usageCnt / total.goalUsageCnt);
     total.totalCnt = itemsQuery.data.length;
-    total.achivedPercent = total.achivedCnt / total.totalCnt;
+    total.achivedPercent = Math.round(total.achivedCnt / total.totalCnt);
   }
 
   return (

--- a/src/Components/Item/Info/AllInfo.jsx
+++ b/src/Components/Item/Info/AllInfo.jsx
@@ -26,9 +26,13 @@ export default function AllInfo({ category }) {
       total.goalUsageCnt += Number(item.goalUsageCount);
       return item.usageCount >= item.goalUsageCount;
     }).length;
-    total.usagePercent = Math.round(total.usageCnt / total.goalUsageCnt);
+    total.usagePercent = Math.round(
+      (total.usageCnt / total.goalUsageCnt) * 100
+    );
     total.totalCnt = itemsQuery.data.length;
-    total.achivedPercent = Math.round(total.achivedCnt / total.totalCnt);
+    total.achivedPercent = Math.round(
+      (total.achivedCnt / total.totalCnt) * 100
+    );
   }
 
   return (

--- a/src/Components/Item/List/ItemList.jsx
+++ b/src/Components/Item/List/ItemList.jsx
@@ -5,12 +5,7 @@ import { useNavigate } from "react-router-dom";
 import { getItemList } from "../../../Api/item";
 import * as S from "./style";
 
-export default function ItemList({
-  itemListOf,
-  infoItemId,
-  setInfoItemId,
-  setInfoItemCategory,
-}) {
+export default function ItemList({ itemListOf, infoItemId, setInfoItemId }) {
   const itemListQuery = useQuery({
     queryKey: [`${itemListOf}`, "list"],
     queryFn: () => {
@@ -67,12 +62,10 @@ export default function ItemList({
             onClick={() => {
               scrollToId(item.id);
               setInfoItemId(item.id);
-              setInfoItemCategory(item.category);
             }}
             onKeyDown={() => {
               scrollToId(item.id);
               setInfoItemId(item.id);
-              setInfoItemCategory(item.category);
             }}
           >
             <S.ItemImg

--- a/src/Components/Item/List/ItemListBox.jsx
+++ b/src/Components/Item/List/ItemListBox.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import ItemListTabBtns from "./ItemListTabBtns";
 import ItemList from "./ItemList";
 import * as S from "./style";
@@ -6,17 +6,18 @@ import * as S from "./style";
 export default function ItemListBox({
   infoItemId,
   setInfoItemId,
-  infoItemCategory,
-  setInfoItemCategory,
+  itemListOf,
+  setItemListOf,
 }) {
-  const [itemListOf, setItemListOf] = useState(infoItemCategory);
-
   return (
     <>
       <S.ItemCategoryTabContainer>
         <ItemListTabBtns
           itemListOf={itemListOf}
-          setItemListOf={setItemListOf}
+          setItemListOf={(category) => {
+            setInfoItemId(0);
+            setItemListOf(category);
+          }}
         />
       </S.ItemCategoryTabContainer>
       <S.ItemListContainer>
@@ -24,7 +25,6 @@ export default function ItemListBox({
           itemListOf={itemListOf}
           infoItemId={infoItemId}
           setInfoItemId={setInfoItemId}
-          setInfoItemCategory={setInfoItemCategory}
         />
       </S.ItemListContainer>
     </>

--- a/src/Components/Item/List/ItemListBox.jsx
+++ b/src/Components/Item/List/ItemListBox.jsx
@@ -6,9 +6,10 @@ import * as S from "./style";
 export default function ItemListBox({
   infoItemId,
   setInfoItemId,
+  infoItemCategory,
   setInfoItemCategory,
 }) {
-  const [itemListOf, setItemListOf] = useState("tumbler");
+  const [itemListOf, setItemListOf] = useState(infoItemCategory);
 
   return (
     <>

--- a/src/Pages/Item/Item.jsx
+++ b/src/Pages/Item/Item.jsx
@@ -1,12 +1,16 @@
 import React, { useState } from "react";
+import { useLocation } from "react-router-dom";
 import AllInfo from "../../Components/Item/Info/AllInfo";
 import EachInfo from "../../Components/Item/Info/EachInfo";
 import ItemListBox from "../../Components/Item/List/ItemListBox";
 import * as S from "./style";
 
 const Item = () => {
-  const [infoItemId, setInfoItemId] = useState(0);
-  const [infoItemCategory, setInfoItemCategory] = useState("tumbler");
+  const { state } = useLocation();
+  const [infoItemId, setInfoItemId] = useState(state?.item || 0);
+  const [infoItemCategory, setInfoItemCategory] = useState(
+    state?.category || "tumbler"
+  );
 
   return (
     <>
@@ -21,6 +25,7 @@ const Item = () => {
         <ItemListBox
           infoItemId={infoItemId}
           setInfoItemId={setInfoItemId}
+          infoItemCategory={infoItemCategory}
           setInfoItemCategory={setInfoItemCategory}
         />
       </S.ListLayout>

--- a/src/Pages/Item/Item.jsx
+++ b/src/Pages/Item/Item.jsx
@@ -8,25 +8,23 @@ import * as S from "./style";
 const Item = () => {
   const { state } = useLocation();
   const [infoItemId, setInfoItemId] = useState(state?.item || 0);
-  const [infoItemCategory, setInfoItemCategory] = useState(
-    state?.category || "tumbler"
-  );
+  const [itemListOf, setItemListOf] = useState(state?.category || "tumbler");
 
   return (
     <>
       <S.InfoLayout>
         {infoItemId === 0 ? (
-          <AllInfo />
+          <AllInfo category={itemListOf} />
         ) : (
-          <EachInfo itemId={infoItemId} itemCategory={infoItemCategory} />
+          <EachInfo itemId={infoItemId} itemCategory={itemListOf} />
         )}
       </S.InfoLayout>
       <S.ListLayout>
         <ItemListBox
           infoItemId={infoItemId}
           setInfoItemId={setInfoItemId}
-          infoItemCategory={infoItemCategory}
-          setInfoItemCategory={setInfoItemCategory}
+          itemListOf={itemListOf}
+          setItemListOf={setItemListOf}
         />
       </S.ListLayout>
     </>

--- a/src/Pages/ItemModification/ItemAdd/ItemAdd.jsx
+++ b/src/Pages/ItemModification/ItemAdd/ItemAdd.jsx
@@ -44,9 +44,9 @@ const ItemAdd = () => {
   const queryClient = useQueryClient();
   const itemAddMutation = useMutation({
     mutationFn: postItem,
-    onSuccess: async () => {
+    onSuccess: async (res) => {
       await queryClient.refetchQueries([`${item.category}`, "list"]);
-      navigate(-1);
+      navigate("/item", { state: { item: res.id, category: item.category } });
     },
   });
 
@@ -99,6 +99,7 @@ const ItemAdd = () => {
           submitCallback={
             item.type === "auth" ? addItemOnAuth : addItemOnUnauth
           }
+          category={item.category}
         />
       </ItemEditBorder>
     </ItemEditWrap>

--- a/src/Pages/ItemModification/ItemAdd/ItemAdd.jsx
+++ b/src/Pages/ItemModification/ItemAdd/ItemAdd.jsx
@@ -6,8 +6,7 @@ import React, {
   useRef,
 } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import { useMutation } from "@tanstack/react-query";
-// import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import ItemImage from "./ItemAddImage";
 import ItemAddDetail from "./ItemAddDetail";
 import ItemAddHead from "./ItemAddHead";
@@ -42,11 +41,12 @@ const ItemAdd = () => {
     window.addEventListener("resize", resizeListener);
   });
 
-  // const queryClient = useQueryClient();
+  const queryClient = useQueryClient();
   const itemAddMutation = useMutation({
     mutationFn: postItem,
-    onSuccess: () => {
-      // queryClient.refetchQueries([`${item.category}`, "list"]);
+    onSuccess: async () => {
+      await queryClient.refetchQueries([`${item.category}`, "list"]);
+      navigate(-1);
     },
   });
 
@@ -68,7 +68,6 @@ const ItemAdd = () => {
       );
       formData.append("itemImage", itemImgFile.current);
       itemAddMutation.mutate(formData);
-      navigate(-1);
     },
     [item.type]
   );

--- a/src/Pages/ItemModification/ItemAdd/ItemAddDetail.jsx
+++ b/src/Pages/ItemModification/ItemAdd/ItemAddDetail.jsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import * as S from "../style";
 import useInput from "../../../hooks/useInput";
 
-const ItemAddDetail = ({ submitCallback }) => {
+const ItemAddDetail = ({ submitCallback, category }) => {
   const navigate = useNavigate();
   const [isError, setIsError] = useState(false);
   const [nickname, onNickname] = useInput("");
@@ -80,8 +80,7 @@ const ItemAddDetail = ({ submitCallback }) => {
           <S.CancelBtn
             type="reset"
             onClick={() => {
-              navigate(-1);
-              // TODO: 카테고리 탭 유지한 페이지로 돌아가기
+              navigate("/item", { state: { category } });
             }}
           >
             취소

--- a/src/Pages/ItemModification/ItemEdit/DeleteItemModal.jsx
+++ b/src/Pages/ItemModification/ItemEdit/DeleteItemModal.jsx
@@ -15,17 +15,17 @@ const DeleteItemModal = ({
   const queryClient = useQueryClient();
   const itemDeleteMutation = useMutation({
     mutationFn: deleteItem,
-    onSuccess: () => {
-      queryClient.refetchQueries(["item", Number(item.id)]);
-      queryClient.refetchQueries([`${item.category}`, "list"]);
+    onSuccess: async () => {
+      await queryClient.refetchQueries([`${item.category}`, "list"]);
+      queryClient.removeQueries(["item", Number(item.id)]);
       queryClient.refetchQueries(["title", item.category]);
+      setShowdeleteItemModal(false);
+      navigate(-1);
     },
   });
   const onDeleteItem = useCallback((e) => {
     e.preventDefault();
     itemDeleteMutation.mutate(item.id);
-    setShowdeleteItemModal(false);
-    navigate(-1);
   }, []);
 
   return (

--- a/src/Pages/ItemModification/ItemEdit/DeleteItemModal.jsx
+++ b/src/Pages/ItemModification/ItemEdit/DeleteItemModal.jsx
@@ -20,7 +20,7 @@ const DeleteItemModal = ({
       queryClient.removeQueries(["item", Number(item.id)]);
       queryClient.refetchQueries(["title", item.category]);
       setShowdeleteItemModal(false);
-      navigate(-1);
+      navigate("/item", { state: { category: item.category } });
     },
   });
   const onDeleteItem = useCallback((e) => {

--- a/src/Pages/ItemModification/ItemEdit/ItemEdit.jsx
+++ b/src/Pages/ItemModification/ItemEdit/ItemEdit.jsx
@@ -59,7 +59,7 @@ const ItemEdit = () => {
       await queryClient.refetchQueries([`${item.category}`, "list"]);
       queryClient.refetchQueries(["item", Number(item.id)]);
       queryClient.refetchQueries(["title", item.category]);
-      navigate(-1);
+      navigate("/item", { state: { item: item.id, category: item.category } });
     },
   });
 

--- a/src/Pages/ItemModification/ItemEdit/ItemEdit.jsx
+++ b/src/Pages/ItemModification/ItemEdit/ItemEdit.jsx
@@ -55,10 +55,11 @@ const ItemEdit = () => {
   const queryClient = useQueryClient();
   const itemEditMutation = useMutation({
     mutationFn: patchItem,
-    onSuccess: () => {
+    onSuccess: async () => {
+      await queryClient.refetchQueries([`${item.category}`, "list"]);
       queryClient.refetchQueries(["item", Number(item.id)]);
-      queryClient.refetchQueries([`${item.category}`, "list"]);
       queryClient.refetchQueries(["title", item.category]);
+      return navigate(-1);
     },
   });
 
@@ -80,7 +81,6 @@ const ItemEdit = () => {
       );
       formData.append("itemImage", itemImgFile.current);
       itemEditMutation.mutate({ formData, id: item.id });
-      navigate(-1);
     },
     [itemEditMutation]
   );

--- a/src/Pages/ItemModification/ItemEdit/ItemEdit.jsx
+++ b/src/Pages/ItemModification/ItemEdit/ItemEdit.jsx
@@ -59,7 +59,7 @@ const ItemEdit = () => {
       await queryClient.refetchQueries([`${item.category}`, "list"]);
       queryClient.refetchQueries(["item", Number(item.id)]);
       queryClient.refetchQueries(["title", item.category]);
-      return navigate(-1);
+      navigate(-1);
     },
   });
 

--- a/src/Pages/ItemModification/ItemEdit/ItemEditDetail.jsx
+++ b/src/Pages/ItemModification/ItemEdit/ItemEditDetail.jsx
@@ -88,8 +88,9 @@ const ItemEditDetail = ({ itemDetail, editCallback }) => {
           <S.CancelBtn
             type="reset"
             onClick={() => {
-              navigate(-1);
-              // TODO: 카테고리 탭 유지한 페이지로 돌아가기
+              navigate("/item", {
+                state: { item: itemDetail.id, category: itemDetail.category },
+              });
             }}
           >
             취소


### PR DESCRIPTION
## 개요
- 아이템 추가/수정 후 리스트에서 포커싱 유지

## 작업사항
- `navigate`할 때 넘겨주는 `state` 객체 이용하여 포커싱할 아이템, 카테고리 state의 초기값으로 사용

## 변경로직
- 아이템 추가/편집 : 해당 카테고리, 아이템 포커싱
- 아이템 삭제 : 해당 카테고리 포커싱
- 기본값 : 텀블러 포커싱 + 아이템 포커싱X (전체 아이템 정보)

## 코멘트
이전 api 업뎃 브랜치로부터 체크아웃 했더니 머지 전이라 커밋이 남아있어요 ㅠㅠ
이 브랜치는 가장 마지막 커밋 하나 뿐이니 해당 커밋 changed만 확인해주세요!
이렇게 TODO 하나 해결했다!!!!!뿌듯

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->