### PR TITLE
refact: 아이템 인포 데이터 api 리스트에서 개별로 변경

### DIFF
--- a/src/Components/Item/Info/AllInfo.jsx
+++ b/src/Components/Item/Info/AllInfo.jsx
@@ -52,7 +52,7 @@ export default function AllInfo({ category }) {
           <S.InfoValue>
             {itemsQuery.data?.length}개<br />
             {total.achivedCnt}개<br />
-            {total.achivedPercent}%
+            {Number.isNaN(total.achivedPercent) ? "0" : total.achivedPercent}%
           </S.InfoValue>
         </S.ContentPart>
         <S.ContentPart>
@@ -67,7 +67,8 @@ export default function AllInfo({ category }) {
           <S.InfoValue>
             {total.usageCnt}회<br />
             {total.goalUsageCnt}회<br />
-            {total.usagePercent}%<br />
+            {Number.isNaN(total.achivedPercent) ? "0" : total.achivedPercent}%
+            <br />
           </S.InfoValue>
         </S.ContentPart>
       </S.InfoContentsDiv>

--- a/src/Components/Item/Info/AllInfo.jsx
+++ b/src/Components/Item/Info/AllInfo.jsx
@@ -19,7 +19,6 @@ export default function AllInfo({ category }) {
     },
   });
 
-  if (itemsQuery.isLoading || itemsQuery.isError) return null;
   if (itemsQuery.isSuccess) {
     total.achivedCnt = itemsQuery.data.filter((item) => {
       total.usageCnt += Number(item.currentUsageCount);

--- a/src/Components/Item/Info/EachInfo.jsx
+++ b/src/Components/Item/Info/EachInfo.jsx
@@ -1,24 +1,21 @@
 import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { getItemList } from "../../../Api/item";
+import { getItem } from "../../../Api/item";
 import TitleSetModal from "../../Modal/TitleSetModal";
 import * as S from "./style";
 
 export default function EachInfo({ itemId, itemCategory }) {
+  const navigate = useNavigate();
   const [modalIsOpen, setModalIsOpen] = useState(false);
-  const itemListQuery = useQuery({
-    queryKey: [`${itemCategory}`, "list"],
+
+  const itemQuery = useQuery({
+    queryKey: ["item", Number(itemId)],
     queryFn: () => {
-      return getItemList(itemCategory);
+      return getItem(itemId);
     },
   });
 
-  const infoItem = itemListQuery.data?.filter((item) => {
-    return item.id === itemId;
-  })[0];
-
-  const navigate = useNavigate();
   const editObj = {
     id: itemId,
     type: "auth",
@@ -30,8 +27,8 @@ export default function EachInfo({ itemId, itemCategory }) {
       {modalIsOpen && (
         <TitleSetModal
           queryData={{
-            itemId: Number(itemId),
-            category: infoItem.category,
+            itemId,
+            category: itemCategory,
           }}
           onClose={() => {
             setModalIsOpen(false);
@@ -40,17 +37,17 @@ export default function EachInfo({ itemId, itemCategory }) {
       )}
       <S.InfoContainer>
         <S.InfoHeaderDiv>
-          <span>{infoItem.nickname}</span>
+          <span>{itemQuery.data?.nickname}</span>
           <S.InfoBtnContainer>
             <S.TitleSetBtn
-              isTitle={infoItem.isTitle}
-              disabled={infoItem.isTitle}
+              isTitle={itemQuery.data?.isTitle}
+              disabled={itemQuery.data?.isTitle}
               type="button"
               onClick={() => {
                 setModalIsOpen(true);
               }}
             >
-              {infoItem.isTitle ? "대표아이템" : "대표 설정"}
+              {itemQuery.data?.isTitle ? "대표아이템" : "대표 설정"}
             </S.TitleSetBtn>
             <S.ModifyBtn
               type="button"
@@ -69,15 +66,15 @@ export default function EachInfo({ itemId, itemCategory }) {
               <br />
               타입
               <br />
-              {infoItem.price ? "구입가" : ""}
+              {itemQuery.data?.price ? "구입가" : ""}
               <br />
             </S.InfoLabel>
             <S.InfoValue>
-              {infoItem.brand || ""}
+              {itemQuery.data?.brand || ""}
               <br />
-              {infoItem.type || ""}
+              {itemQuery.data?.type || ""}
               <br />
-              {infoItem.price ? `${infoItem.price}원` : ""}
+              {itemQuery.data?.price ? `${itemQuery.data?.price}원` : ""}
             </S.InfoValue>
           </S.ContentPart>
           <S.ContentPart>
@@ -86,15 +83,17 @@ export default function EachInfo({ itemId, itemCategory }) {
               <br />
               목표횟수
               <br />
-              {infoItem.purchaseDate ? "구입일" : ""}
+              {itemQuery.data?.purchaseDate ? "구입일" : ""}
               <br />
             </S.InfoLabel>
             <S.InfoValue>
-              {infoItem.currentUsageCount}회
+              {itemQuery.data?.currentUsageCount}회
               <br />
-              {infoItem.goalUsageCount}회
+              {itemQuery.data?.goalUsageCount}회
               <br />
-              {infoItem.purchaseDate ? infoItem.purchaseDate.slice(0, 10) : ""}
+              {itemQuery.data?.purchaseDate
+                ? itemQuery.data?.purchaseDate.slice(0, 10)
+                : ""}
             </S.InfoValue>
           </S.ContentPart>
         </S.InfoContentsDiv>

--- a/src/Components/Item/Info/EachInfo.jsx
+++ b/src/Components/Item/Info/EachInfo.jsx
@@ -1,5 +1,5 @@
-import { useQuery } from "@tanstack/react-query";
 import React, { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import { getItem } from "../../../Api/item";
 import TitleSetModal from "../../Modal/TitleSetModal";
@@ -64,7 +64,7 @@ export default function EachInfo({ itemId, itemCategory }) {
             <S.InfoLabel>
               브랜드
               <br />
-              타입
+              {itemQuery.data?.type !== "" ? "타입" : ""}
               <br />
               {itemQuery.data?.price ? "구입가" : ""}
               <br />

--- a/src/Components/Modal/TitleSetModal.jsx
+++ b/src/Components/Modal/TitleSetModal.jsx
@@ -1,6 +1,6 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import React, { useRef } from "react";
-import { patchTitleItem } from "../../Api/item";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { getTitleItem, patchTitleItem } from "../../Api/item";
 import useOutsideClick from "../../hooks/useOutsideClick";
 import SmallModal from "./SmallModal";
 import * as S from "./style";
@@ -9,16 +9,24 @@ export default function TitleSetModal({ queryData, onClose }) {
   const modalRef = useRef();
   useOutsideClick(modalRef, onClose);
 
+  const prevTitleId = useQuery({
+    queryKey: ["title", queryData.category],
+    queryFn: () => {
+      getTitleItem(queryData.category);
+    },
+  }).data?.id;
+
   const queryClient = useQueryClient();
   const titleMutation = useMutation({
     mutationFn: () => {
       return patchTitleItem(queryData);
     },
-    onSuccess: (res) => {
-      queryClient.setQueryData(["title", `${queryData.category}`], res);
+    onSuccess: async (res) => {
+      queryClient.setQueryData(["item", res.id], res);
+      queryClient.setQueryData(["title", res.category], res);
+      queryClient.invalidateQueries(["title", res.category]);
+      await queryClient.refetchQueries(["item", prevTitleId]);
       onClose();
-      queryClient.refetchQueries(["title", `${queryData.category}`]);
-      queryClient.refetchQueries([`${queryData.category}`, "list"]);
     },
   });
 

--- a/src/hooks/useOutsideClick.jsx
+++ b/src/hooks/useOutsideClick.jsx
@@ -10,5 +10,5 @@ export default function useOutsideClick(modalRef, onClose) {
     return () => {
       return window.removeEventListener("mousedown", handleClick);
     };
-  });
+  }, [modalRef]);
 }


### PR DESCRIPTION
## 개요
- 아이템 인포 데이터 api 리스트에서 개별로 변경

## 작업사항
- EachInfo 컴포넌트에서 사용하는 api 전체리스트 불러오기 -> 개별아이템 불러오기로 변경

## 코멘트
최근 작업하면서 둘러보다가 EachInfo가 전체리스트 api로 되어있길래 대표아이템 떄문이었던 것 같긴 한데, 자세히 기억이 안나서 이전 커밋/PR 확인해보니 수정가능한 부분이라서 수정했습니다!

리스트 데이터가 무조건 캐싱되어 있으니 리스트를 그대로 쓰는게 api 리소스 측면에서 나은가? 그냥 둘까? 라는 생각을 잠시 해보았는데, 리스트에서 해당 아이템 데이터 찾는게 O(n)이니까 리스트가 혹시라도 길어지면 개별아이템 api가 낫지 않나 + EachInfo라는 목적에 맞게 개별아이템 api가 맞다! 라는 생각으로 수정해봤습니다

결론적으로 타이틀아이템 api + 개별아이템 api까지 2번 호출한 셈이니..뭐가 더 나은건지 아직도 잘 모르겠어!!!!!!!!!!!어떻게 생각하시나요???


<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->