### PR TITLE
feat: 아이템 추가/수정에서 필수 부분 강조, 글자크기 조정, 버그 수정

### DIFF
--- a/src/pages/item/components/modification/ItemAdd/ItemAddDetail.jsx
+++ b/src/pages/item/components/modification/ItemAdd/ItemAddDetail.jsx
@@ -25,7 +25,9 @@ const ItemAddDetail = ({ category, submitCallback, onCancel }) => {
     <S.Form onSubmit={handleSubmit}>
       <S.FormInnerWrapper>
         <S.LabelInputSet>
-          <S.Span>닉네임</S.Span>
+          <S.Span>
+            닉네임 <span style={{ color: "red" }}>*</span>
+          </S.Span>
           <S.Input
             value={nickname}
             onChange={onNickname}
@@ -35,7 +37,9 @@ const ItemAddDetail = ({ category, submitCallback, onCancel }) => {
           />
         </S.LabelInputSet>
         <S.LabelInputSet>
-          <S.Span>브랜드</S.Span>
+          <S.Span>
+            브랜드 <span style={{ color: "red" }}>*</span>
+          </S.Span>
           <S.Input
             value={brand}
             onChange={onBrand}
@@ -78,7 +82,7 @@ const ItemAddDetail = ({ category, submitCallback, onCancel }) => {
           marginTop: "1%",
         }}
       >
-        {isError && <S.Error>닉네임, 브랜드는 필수입니다.</S.Error>}
+        {isError && <S.Error>닉네임과 브랜드는 꼭 작성해주세요!</S.Error>}
       </div>
       <S.ButtonWrapper>
         <S.CancelBtn type="reset" onClick={onCancel}>

--- a/src/pages/item/components/modification/ItemAdd/ItemAddHead.jsx
+++ b/src/pages/item/components/modification/ItemAdd/ItemAddHead.jsx
@@ -1,10 +1,10 @@
 import React from "react";
-import { ItemEditHeadWrapper } from "../style";
+import { ItemEditHeadWrapper, Span } from "../style";
 
 const ItemEditHead = ({ category }) => {
   return (
     <ItemEditHeadWrapper>
-      {category === "tumbler" ? "텀블러 추가" : "에코백 추가"}
+      <Span>{category === "tumbler" ? "텀블러 추가" : "에코백 추가"}</Span>
     </ItemEditHeadWrapper>
   );
 };

--- a/src/pages/item/components/modification/ItemEdit/ItemEdit.jsx
+++ b/src/pages/item/components/modification/ItemEdit/ItemEdit.jsx
@@ -64,7 +64,7 @@ const ItemEditOnAuth = () => {
   return (
     <ItemEdit
       category={item.category}
-      item={prevItemInfoQuery.data}
+      item={{ ...prevItemInfoQuery.data, type: item.type }}
       onCancel={hancleCancel}
       onSubmit={editItemOnAuth}
       onUploadImg={setItemImgFile}

--- a/src/pages/item/components/modification/ItemEdit/ItemEditDetail.jsx
+++ b/src/pages/item/components/modification/ItemEdit/ItemEditDetail.jsx
@@ -7,7 +7,9 @@ const ItemEditDetail = ({ itemDetail, editCallback, onCancel }) => {
   const [nickname, onNickname] = useInput(itemDetail.nickname);
   const [brand, onBrand] = useInput(itemDetail.brand);
   const [price, onPrice] = useInput(itemDetail.price);
-  const [purchaseDate, onPurchaseData] = useInput(itemDetail.purchaseDate);
+  const [purchaseDate, onPurchaseData] = useInput(
+    itemDetail.purchaseDate ?? ""
+  );
   const [type, onType] = useInput(itemDetail.type);
   const targetGoalUsageCount = itemDetail.goalUsageCount;
 
@@ -25,7 +27,9 @@ const ItemEditDetail = ({ itemDetail, editCallback, onCancel }) => {
     <S.Form onSubmit={handleSubmit}>
       <S.FormInnerWrapper>
         <S.LabelInputSet>
-          <S.Span>닉네임</S.Span>
+          <S.Span>
+            닉네임<span style={{ color: "red" }}>*</span>
+          </S.Span>
           <S.Input
             value={nickname}
             onChange={onNickname}
@@ -36,7 +40,9 @@ const ItemEditDetail = ({ itemDetail, editCallback, onCancel }) => {
           />
         </S.LabelInputSet>
         <S.LabelInputSet>
-          <S.Span>브랜드</S.Span>
+          <S.Span>
+            브랜드<span style={{ color: "red" }}>*</span>
+          </S.Span>
           <S.Input
             value={brand}
             onChange={onBrand}
@@ -84,7 +90,7 @@ const ItemEditDetail = ({ itemDetail, editCallback, onCancel }) => {
           />
         </S.LabelInputSet>
       </S.FormInnerWrapper>
-      {isError && <S.Error>닉네임, 브랜드는 필수입니다.</S.Error>}
+      {isError && <S.Error>닉네임과 브랜드는 꼭 작성해주세요!</S.Error>}
       <S.ButtonWrapper>
         <S.CancelBtn type="reset" onClick={onCancel}>
           취소

--- a/src/pages/item/components/modification/ItemEdit/ItemEditHead.jsx
+++ b/src/pages/item/components/modification/ItemEdit/ItemEditHead.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback } from "react";
-import { ItemEditHeadWrapper, DeleteBtn } from "../style";
+import { ItemEditHeadWrapper, DeleteBtn, Span } from "../style";
 
 const ItemEditHead = ({ item, setShowdeleteItemModal }) => {
   const onclickDeleteItemModal = useCallback((e) => {
@@ -11,7 +11,7 @@ const ItemEditHead = ({ item, setShowdeleteItemModal }) => {
 
   return (
     <ItemEditHeadWrapper>
-      {item.category === "tumbler" ? "텀블러 수정" : "에코백 수정"}
+      <Span>{item.category === "tumbler" ? "텀블러 수정" : "에코백 수정"}</Span>
       {item.type === "auth" && (
         <DeleteBtn onClick={onclickDeleteItemModal}>삭제</DeleteBtn>
       )}

--- a/src/pages/item/components/modification/style.jsx
+++ b/src/pages/item/components/modification/style.jsx
@@ -68,7 +68,7 @@ export const LabelInputSet = styled.div`
 `;
 
 export const Span = styled.span`
-  width: 70px;
+  width: 80px;
   ${font.boldBody};
 `;
 


### PR DESCRIPTION
## 개요
- 아주 오래 전 얘기했던.. 아이템 추가/수정 페이지에서 필수 부분 강조표시와 
해당 페이지에서 수정 필요해보이는 부분 추가 작업

## 작업사항
- 추가/수정 페이지에서 필수 부분인 닉네임과 브랜드에 빨간 별로 강조
- 추가/수정 페에지 상단에서  카테고리 부분을 span으로 감쌈,
   그에 따라 span 스타일 컴포넌트의 너비 증가가 필요해서 너비 10px 증가
- 버그 확인 후 수정 
   1. 수정페이지에서 구매일이 null로 받아오면 콘솔에 error 찍힘 현상
   null일때 공백문자열로 대치되게 수정` (null ?? "")`
   2. 수정페이지에서 넘겨받은 item 안에 type 정보가 누락된채로 하위컴포넌트로 넘겨줌 -> 수정 
    페이지 상단에 삭제 버튼 보이지 않음 현상 
    일단 ...으로 풀어서 type 추가

