### PR TITLE
feat: 반응형 nav bar 구현

### DIFF
--- a/src/layout/private/index.jsx
+++ b/src/layout/private/index.jsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { Navigate, Outlet, useLocation } from "react-router-dom";
-import { useMediaQuery } from "react-responsive";
 
 import TabBar from "./tabBar/TabBar";
 
@@ -10,17 +9,9 @@ const PrivateLayout = () => {
   const { pathname } = useLocation();
   if (pathname === "/") return <Navigate to="/home" />;
 
-  // TEST: 기기 확인을 위한 임시 표시
-  const isPc = useMediaQuery({
-    query: "(min-width:471px)",
-  });
-
   return (
     <S.PageLayout>
       <S.Layout>
-        <h3 style={{ position: "absolute", left: 20 }}>
-          {isPc ? "pc" : "mobile"}
-        </h3>
         <S.OutletWrapper fixedWidth>
           <Outlet />
         </S.OutletWrapper>

--- a/src/layout/private/tabBar/TabBar.jsx
+++ b/src/layout/private/tabBar/TabBar.jsx
@@ -1,23 +1,30 @@
 import React from "react";
 import { TabBarContainer } from "./style";
 import TabItem from "./TabItem";
-import { AiFillSetting } from "react-icons/ai";
-import { BiHomeAlt } from "react-icons/bi";
-import { BsFillBoxFill } from "react-icons/bs";
+import {
+  AiFillHome,
+  AiOutlineHome,
+  AiFillSetting,
+  AiOutlineSetting,
+} from "react-icons/ai";
+import { BsBox, BsFillBoxFill } from "react-icons/bs";
 
 const TabBar = () => {
   const routeInfo = [
     {
       page: "/setting",
-      icon: AiFillSetting,
+      icon: AiOutlineSetting,
+      iconClicked: AiFillSetting,
     },
     {
       page: "/home",
-      icon: BiHomeAlt,
+      icon: AiOutlineHome,
+      iconClicked: AiFillHome,
     },
     {
       page: "/item",
-      icon: BsFillBoxFill,
+      icon: BsBox,
+      iconClicked: BsFillBoxFill,
     },
   ];
 
@@ -28,6 +35,7 @@ const TabBar = () => {
           <TabItem
             key={element.page}
             IconComponent={element.icon}
+            ClickedComponent={element.iconClicked}
             page={element.page}
           />
         );

--- a/src/layout/private/tabBar/TabBar.jsx
+++ b/src/layout/private/tabBar/TabBar.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { TabBarContainer } from "./style";
+import { TabBarContainer, LogoWrapper, Logo } from "./style";
 import TabItem from "./TabItem";
 import {
   AiFillHome,
@@ -7,7 +7,7 @@ import {
   AiFillSetting,
   AiOutlineSetting,
 } from "react-icons/ai";
-import { BsBox, BsFillBoxFill } from "react-icons/bs";
+import { HiOutlineArchive, HiArchive } from "react-icons/hi";
 
 const TabBar = () => {
   const routeInfo = [
@@ -23,13 +23,16 @@ const TabBar = () => {
     },
     {
       page: "/item",
-      icon: BsBox,
-      iconClicked: BsFillBoxFill,
+      icon: HiOutlineArchive,
+      iconClicked: HiArchive,
     },
   ];
 
   return (
     <TabBarContainer>
+      <LogoWrapper>
+        <Logo src="/logo.png" alt="ecopercent" />
+      </LogoWrapper>
       {routeInfo.map((element) => {
         return (
           <TabItem

--- a/src/layout/private/tabBar/TabBar.jsx
+++ b/src/layout/private/tabBar/TabBar.jsx
@@ -12,19 +12,22 @@ import { HiOutlineArchive, HiArchive } from "react-icons/hi";
 const TabBar = () => {
   const routeInfo = [
     {
-      page: "/setting",
-      icon: AiOutlineSetting,
-      iconClicked: AiFillSetting,
-    },
-    {
       page: "/home",
       icon: AiOutlineHome,
       iconClicked: AiFillHome,
+      description: "홈",
     },
     {
       page: "/item",
       icon: HiOutlineArchive,
       iconClicked: HiArchive,
+      description: "아이템",
+    },
+    {
+      page: "/setting",
+      icon: AiOutlineSetting,
+      iconClicked: AiFillSetting,
+      description: "설정",
     },
   ];
 
@@ -40,6 +43,7 @@ const TabBar = () => {
             IconComponent={element.icon}
             ClickedComponent={element.iconClicked}
             page={element.page}
+            description={element.description}
           />
         );
       })}

--- a/src/layout/private/tabBar/TabItem.jsx
+++ b/src/layout/private/tabBar/TabItem.jsx
@@ -1,10 +1,10 @@
 import React, { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
-import { TabItemBackGround } from "./style";
+import { LinkWrapper, TabItemBackGround, Description } from "./style";
 import styled from "@emotion/styled";
 import media from "@style/media";
 
-const TabItem = ({ IconComponent, ClickedComponent, page }) => {
+const TabItem = ({ IconComponent, ClickedComponent, page, description }) => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const tabClickHandler = useCallback(() => {
@@ -32,9 +32,12 @@ const TabItem = ({ IconComponent, ClickedComponent, page }) => {
   `;
 
   return (
-    <TabItemBackGround featured={pathname === page} onClick={tabClickHandler}>
-      {pathname === page ? <ClickedIcon /> : <UnclickedIcon />}
-    </TabItemBackGround>
+    <LinkWrapper onClick={tabClickHandler}>
+      <TabItemBackGround featured={pathname === page}>
+        {pathname === page ? <ClickedIcon /> : <UnclickedIcon />}
+      </TabItemBackGround>
+      <Description>{description}</Description>
+    </LinkWrapper>
   );
 };
 

--- a/src/layout/private/tabBar/TabItem.jsx
+++ b/src/layout/private/tabBar/TabItem.jsx
@@ -2,7 +2,7 @@ import React, { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { TabItemBackGround } from "./style";
 
-const TabItem = ({ IconComponent, page }) => {
+const TabItem = ({ IconComponent, ClickedComponent, page }) => {
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const tabClickHandler = useCallback(() => {
@@ -11,12 +11,16 @@ const TabItem = ({ IconComponent, page }) => {
 
   return (
     <TabItemBackGround featured={pathname === page} onClick={tabClickHandler}>
-      <IconComponent
-        style={{
-          width: "20px",
-          height: "20px",
-        }}
-      />
+      {pathname === page ? (
+        <ClickedComponent style={{ width: "20px", height: "20px" }} />
+      ) : (
+        <IconComponent
+          style={{
+            width: "20px",
+            height: "20px",
+          }}
+        />
+      )}
     </TabItemBackGround>
   );
 };

--- a/src/layout/private/tabBar/TabItem.jsx
+++ b/src/layout/private/tabBar/TabItem.jsx
@@ -1,6 +1,8 @@
 import React, { useCallback } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { TabItemBackGround } from "./style";
+import styled from "@emotion/styled";
+import media from "@style/media";
 
 const TabItem = ({ IconComponent, ClickedComponent, page }) => {
   const { pathname } = useLocation();
@@ -9,18 +11,29 @@ const TabItem = ({ IconComponent, ClickedComponent, page }) => {
     navigate(`${page}`);
   }, []);
 
+  const ClickedIcon = styled(ClickedComponent)`
+    width: 30px;
+    height: 30px;
+
+    @media ${media.mobile} {
+      width: 25px;
+      height: 25px;
+    }
+  `;
+
+  const UnclickedIcon = styled(IconComponent)`
+    width: 30px;
+    height: 30px;
+
+    @media ${media.mobile} {
+      width: 25px;
+      height: 25px;
+    }
+  `;
+
   return (
     <TabItemBackGround featured={pathname === page} onClick={tabClickHandler}>
-      {pathname === page ? (
-        <ClickedComponent style={{ width: "20px", height: "20px" }} />
-      ) : (
-        <IconComponent
-          style={{
-            width: "20px",
-            height: "20px",
-          }}
-        />
-      )}
+      {pathname === page ? <ClickedIcon /> : <UnclickedIcon />}
     </TabItemBackGround>
   );
 };

--- a/src/layout/private/tabBar/style.jsx
+++ b/src/layout/private/tabBar/style.jsx
@@ -1,19 +1,46 @@
 import styled from "@emotion/styled";
 import { basicGreen } from "@style/color";
+import media from "@style/media";
 
 export const TabBarContainer = styled.div`
   display: flex;
   height: 100%;
-  border-top: 0.5px solid;
+
+  @media ${media.mobile}, ${media.tabletSmallMin} and ${media.tabletSmallMax} {
+    border-top: 0.5px solid;
+  }
+
+  @media ${media.desktop}, ${media.tabletMin} and ${media.tabletMax} {
+    width: 72px;
+    position: fixed;
+    left: 0;
+    top: 0;
+
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    border-right: 0.5px solid;
+  }
+`;
+
+export const LogoWrapper = styled.div`
+  width: 50px;
+
+  @media ${media.mobile}, ${media.tabletSmallMin} and ${media.tabletSmallMax} {
+    display: none;
+  }
+  margin: 30px 0;
+  padding: 0 5px;
+`;
+
+export const Logo = styled.img`
+  width: 100%;
 `;
 
 export const TabItemBackGround = styled.div`
-  width: calc(100% / 3);
-
   display: flex;
-  justify-content: center;
   align-items: center;
-  cursor: pointer;
+  justify-content: center;
 
   ${(props) => {
     return props.featured ? `color: ${basicGreen};` : "";
@@ -23,4 +50,16 @@ export const TabItemBackGround = styled.div`
     background-color: ${basicGreen};
     color: white;
   }
+
+  @media ${media.desktop}, ${media.tabletMin} and ${media.tabletMax} {
+    border-radius: 50%;
+    width: 40px;
+    height: 40px;
+  }
+
+  @media ${media.mobile}, ${media.tabletSmallMin} and ${media.tabletSmallMax} {
+    width: calc(100% / 3);
+  }
+
+  cursor: pointer;
 `;

--- a/src/layout/private/tabBar/style.jsx
+++ b/src/layout/private/tabBar/style.jsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { basicGreen } from "@style/color";
+import { lightGreen, basicGreen } from "@style/color";
 import media from "@style/media";
 
 export const TabBarContainer = styled.div`
@@ -18,23 +18,50 @@ export const TabBarContainer = styled.div`
 
     flex-direction: column;
     align-items: center;
-    gap: 20px;
+    gap: 10px;
     border-right: 0.5px solid;
+  }
+
+  @media ${media.desktop} {
+    width: 220px;
   }
 `;
 
 export const LogoWrapper = styled.div`
-  width: 50px;
+  width: 100%;
+  margin: 30px 0 30px 30px;
+  padding: 0 5px;
 
   @media ${media.mobile}, ${media.tabletSmallMin} and ${media.tabletSmallMax} {
     display: none;
   }
-  margin: 30px 0;
-  padding: 0 5px;
 `;
 
 export const Logo = styled.img`
-  width: 100%;
+  width: 35px;
+`;
+
+export const LinkWrapper = styled.div`
+  @media ${media.desktop}, ${media.tabletMin} and ${media.tabletMax} {
+    display: flex;
+    align-items: center;
+    margin: 0 10px;
+    width: calc(100% - 20px);
+    padding: 5px 0;
+    padding-left: 6px;
+    gap: 8px;
+
+    border-radius: 20px;
+    :hover {
+      background-color: ${lightGreen};
+    }
+    cursor: pointer;
+  }
+
+  @media ${media.mobile}, ${media.tabletSmallMin} and ${media.tabletSmallMax} {
+    display: flex;
+    width: calc(100% / 3);
+  }
 `;
 
 export const TabItemBackGround = styled.div`
@@ -42,14 +69,11 @@ export const TabItemBackGround = styled.div`
   align-items: center;
   justify-content: center;
 
+  cursor: pointer;
+
   ${(props) => {
     return props.featured ? `color: ${basicGreen};` : "";
   }}
-
-  :hover {
-    background-color: ${basicGreen};
-    color: white;
-  }
 
   @media ${media.desktop}, ${media.tabletMin} and ${media.tabletMax} {
     border-radius: 50%;
@@ -58,8 +82,19 @@ export const TabItemBackGround = styled.div`
   }
 
   @media ${media.mobile}, ${media.tabletSmallMin} and ${media.tabletSmallMax} {
-    width: calc(100% / 3);
-  }
+    width: 100%;
 
-  cursor: pointer;
+    :hover {
+      background-color: ${basicGreen};
+      color: white;
+    }
+  }
+`;
+
+export const Description = styled.span`
+  display: none;
+
+  @media ${media.desktop} {
+    display: inline;
+  }
 `;

--- a/src/layout/private/tabBar/style.jsx
+++ b/src/layout/private/tabBar/style.jsx
@@ -100,5 +100,6 @@ export const Description = styled.span`
 
   @media ${media.desktop} {
     display: inline;
+    vertical-align: middle;
   }
 `;

--- a/src/layout/private/tabBar/style.jsx
+++ b/src/layout/private/tabBar/style.jsx
@@ -52,8 +52,10 @@ export const LinkWrapper = styled.div`
     gap: 8px;
 
     border-radius: 20px;
-    :hover {
-      background-color: ${lightGreen};
+    @media (hover: hover) and (pointer: fine) {
+      :hover {
+        background-color: ${lightGreen};
+      }
     }
     cursor: pointer;
   }
@@ -84,9 +86,11 @@ export const TabItemBackGround = styled.div`
   @media ${media.mobile}, ${media.tabletSmallMin} and ${media.tabletSmallMax} {
     width: 100%;
 
-    :hover {
-      background-color: ${basicGreen};
-      color: white;
+    @media (hover: hover) and (pointer: fine) {
+      :hover {
+        background-color: ${basicGreen};
+        color: white;
+      }
     }
   }
 `;

--- a/src/layout/public/index.jsx
+++ b/src/layout/public/index.jsx
@@ -1,21 +1,12 @@
 import React from "react";
 import { Outlet } from "react-router-dom";
-import { useMediaQuery } from "react-responsive";
 
 import * as S from "../style";
 
 const PublicLayout = () => {
-  // TEST: 기기 확인을 위한 임시 표시
-  const isPc = useMediaQuery({
-    query: "(min-width:471px)",
-  });
-
   return (
     <S.PageLayout>
       <S.Layout>
-        <h3 style={{ position: "absolute", left: 20 }}>
-          {isPc ? "pc" : "mobile"}
-        </h3>
         <S.OutletWrapper>
           <Outlet />
         </S.OutletWrapper>

--- a/src/layout/style.jsx
+++ b/src/layout/style.jsx
@@ -21,29 +21,22 @@ export const OutletWrapper = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 0 auto;
-  height: calc(100% - 48px);
+  height: calc(var(--vh, 1vh) * 100 - 48px);
 
   @media not ${media.mobile} {
     ${(props) => {
       if (props.fixedWidth) return `width: 500px; margin: 0 auto;`;
       return ``;
     }}
-    ${(props) => {
-      if (props.fullHeight) return `height: 100%;`;
-      return ``;
-    }}
   }
 
-  @media ${media.mobile} {
-    height: calc(var(--vh, 1vh) * 100 - 48px);
-    ${(props) => {
-      if (props.fullHeight) return `height: calc(var(--vh, 1vh) * 100);`;
-      return ``;
-    }}
-  }
+  ${(props) => {
+    if (props.fullHeight) return `height: calc(var(--vh, 1vh) * 100);`;
+    return ``;
+  }}
 
   @media ${media.desktop}, ${media.tabletMin} and ${media.tabletMax} {
-    height: 100%;
+    height: calc(var(--vh, 1vh) * 100);
   }
 `;
 

--- a/src/layout/style.jsx
+++ b/src/layout/style.jsx
@@ -12,23 +12,8 @@ export const Layout = styled.div`
   display: flex;
   flex-direction: column;
 
-  /* TODO: width에 따른 반응형 탭바 구현해보기 */
-  @media ${media.desktop} {
-    /* background-color: lightblue; */
-  }
-
-  @media ${media.tabletM} {
-    /* background-color: lightcoral; */
-  }
-
-  @media ${media.tabletS} {
-    /* background-color: lightgreen; */
-  }
-
   @media ${media.mobile} {
     height: calc(var(--vh, 1vh) * 100);
-
-    /* background-color: lightyellow; */
   }
 `;
 
@@ -55,6 +40,10 @@ export const OutletWrapper = styled.div`
       if (props.fullHeight) return `height: calc(var(--vh, 1vh) * 100);`;
       return ``;
     }}
+  }
+
+  @media ${media.desktop}, ${media.tabletMin} and ${media.tabletMax} {
+    height: 100%;
   }
 `;
 

--- a/src/pages/error/style.jsx
+++ b/src/pages/error/style.jsx
@@ -39,7 +39,9 @@ export const GoHomeBtn = styled.button`
   height: 40px;
   width: 100px;
 
-  :hover {
-    background: ${basicGreen};
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      background: ${basicGreen};
+    }
   }
 `;

--- a/src/pages/setting/style.jsx
+++ b/src/pages/setting/style.jsx
@@ -28,18 +28,23 @@ export const HoverSettingTitle = styled.div`
   margin-bottom: 2.5%;
   font-size: 22px;
   font-weight: bold;
-  :hover {
-    background: ${basicGreen};
-    color: white;
+
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      background: ${basicGreen};
+      color: white;
+    }
   }
 `;
 
 export const Highlight = styled.div`
   padding: 3%;
   color: ${basicGreen};
-  :hover {
-    background: ${basicGreen};
-    color: white;
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      background: ${basicGreen};
+      color: white;
+    }
   }
   border-radius: 3px;
   cursor: pointer;
@@ -48,9 +53,11 @@ export const Highlight = styled.div`
 export const HighlightPinkHover = styled.div`
   padding: 3%;
   color: ${basicGreen};
-  :hover {
-    background: ${basicPink};
-    color: white;
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      background: ${basicPink};
+      color: white;
+    }
   }
   border-radius: 3px;
   cursor: pointer;
@@ -62,9 +69,11 @@ export const ColorPlain = styled.span`
 
 export const HoverPlain = styled.div`
   padding: 3%;
-  :hover {
-    background: ${basicGreen};
-    color: white;
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      background: ${basicGreen};
+      color: white;
+    }
   }
   border-radius: 3px;
   cursor: pointer;
@@ -72,10 +81,6 @@ export const HoverPlain = styled.div`
 
 export const Plain = styled.div`
   padding: 3%;
-  // :hover {
-  //   background: ${basicGreen};
-  //   color: white;
-  // }
   border-radius: 3px;
 `;
 

--- a/src/pages/signup/style.jsx
+++ b/src/pages/signup/style.jsx
@@ -61,9 +61,9 @@ export const Btn = styled.button`
 
   ${(props) => {
     if (!props.disabled)
-      return `:hover {
-    opacity: 0.7;
-  }`;
+      return `@media (hover: hover) and (pointer: fine) {
+                :hover { opacity: 0.7; }
+              }`;
     return null;
   }}
 `;

--- a/src/style/button.jsx
+++ b/src/style/button.jsx
@@ -19,8 +19,10 @@ export const normal = `
 
   ${font.normalBtn};
 
-  :hover {
-    opacity: 0.7;
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      opacity: 0.7;
+    }
   }
 `;
 

--- a/src/style/media.jsx
+++ b/src/style/media.jsx
@@ -1,14 +1,18 @@
 const size = {
   desktop: "1264px",
-  tabletM: "1263px",
-  tabletS: "770px",
+  tabletMax: "1263px",
+  tabletMin: "761px",
+  tabletSmallMax: "760px",
+  tabletSmallMin: "471px",
   mobile: "470px",
 };
 
 const media = {
   desktop: `(min-width: ${size.desktop})`,
-  tabletM: `(max-width: ${size.tabletM})`,
-  tabletS: `(max-width: ${size.tabletS})`,
+  tabletMax: `(max-width: ${size.tabletMax})`,
+  tabletMin: `(min-width: ${size.tabletMin})`,
+  tabletSmallMax: `(max-width: ${size.tabletSmallMax})`,
+  tabletSmallMin: `(min-width: ${size.tabletSmallMin})`,
   mobile: `(max-width: ${size.mobile})`,
 };
 

--- a/src/style/media.jsx
+++ b/src/style/media.jsx
@@ -1,6 +1,6 @@
 const size = {
-  desktop: "1264px",
-  tabletMax: "1263px",
+  desktop: "1000px",
+  tabletMax: "999px",
   tabletMin: "761px",
   tabletSmallMax: "760px",
   tabletSmallMin: "471px",


### PR DESCRIPTION
## 개요
- 반응형 nav bar 구현

## 작업사항
- 인스타그램에서 차용한 3단계 NavBar
  - 모바일, 웹 작은 너비에서는 하단 아이콘 탭바
  - 웹 중간 너비에서는 왼쪽 아이콘 탭바
  - 웹 큰 너비에서는 왼쪽 아이콘 탭바 + 링크명
- 탭바 아이콘 변경
  - 클릭 전 outline형 아이콘 > 클릭 후 fill형 아이콘
- 탭바 순서 변경(홈-아이템-설정 순)

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->