### PR TITLE
update: 아이템 하루 사용량 서버데이터 연동

### DIFF
--- a/src/pages/home/components/titleItem/titleItem/ItmeImageStroke.jsx
+++ b/src/pages/home/components/titleItem/titleItem/ItmeImageStroke.jsx
@@ -71,7 +71,7 @@ const ItmeImageStroke = ({ itemInfo }) => {
           />
         </foreignObject>
         {(divideNum === 3 ? threeStrockInfo : oneStrockInfo).map((element) => {
-          if (element.key <= divideNum - itemInfo.usageCountPerDay)
+          if (element.key <= divideNum - usageCount)
             return <S.StrokePath d={element.d} key={element.key} />;
           return (
             <S.StrokePath

--- a/src/pages/home/components/titleItem/titleItem/ItmeImageStroke.jsx
+++ b/src/pages/home/components/titleItem/titleItem/ItmeImageStroke.jsx
@@ -50,22 +50,15 @@ const ItmeImageStroke = ({ itemInfo }) => {
   const queryClient = useQueryClient();
   const upUsageCountMutation = useMutation({
     mutationFn: patchUsageCountUp,
-    onSuccess: () => {
-      const newItemInfo = { ...itemInfo };
-      newItemInfo.currentUsageCount += 1;
-      newItemInfo.usageCountPerDay += 1;
-      queryClient.setQueryData(["title", itemInfo.category], newItemInfo);
-      queryClient.invalidateQueries(["title", itemInfo.category]);
+    onSuccess: (updatedItemInfo) => {
+      setUsageCount(updatedItemInfo.usageCountPerDay);
+      queryClient.setQueryData(["title", itemInfo.category], updatedItemInfo);
+      queryClient.refetchQueries(["title", itemInfo.category]);
       queryClient.invalidateQueries([itemInfo.category, "list"]);
     },
   });
   const increaseCount = useCallback(() => {
-    if (usageCount < divideNum) {
-      setUsageCount((currUsageCount) => {
-        return currUsageCount + 1;
-      });
-      upUsageCountMutation.mutate(itemInfo.id);
-    }
+    if (usageCount < divideNum) upUsageCountMutation.mutate(itemInfo.id);
   }, [usageCount]);
 
   return (
@@ -78,7 +71,7 @@ const ItmeImageStroke = ({ itemInfo }) => {
           />
         </foreignObject>
         {(divideNum === 3 ? threeStrockInfo : oneStrockInfo).map((element) => {
-          if (element.key <= divideNum - usageCount)
+          if (element.key <= divideNum - itemInfo.usageCountPerDay)
             return <S.StrokePath d={element.d} key={element.key} />;
           return (
             <S.StrokePath

--- a/src/pages/home/components/titleItem/titleItem/ItmeImageStroke.jsx
+++ b/src/pages/home/components/titleItem/titleItem/ItmeImageStroke.jsx
@@ -22,23 +22,6 @@ function toPieChartItemPath(x, y, radiusIn, radiusOut, startAngle, endAngle) {
   return d;
 }
 
-const makeDateStr = () => {
-  const date = new Date();
-  const year = date.getFullYear();
-  const month = `0${date.getMonth() + 1}`.slice(-2);
-  const day = `0${date.getDate()}`.slice(-2);
-  const dateStr = `${year}-${month}-${day}`;
-  return dateStr;
-};
-
-const checkItemUsageCount = (id, divideNum) => {
-  const itemCountObj = JSON.parse(localStorage.getItem(`item/${id}`));
-  if (itemCountObj && makeDateStr() === itemCountObj.dateStr) {
-    return itemCountObj.count;
-  }
-  return divideNum;
-};
-
 const threeStrockInfo = [
   {
     key: 1,
@@ -63,31 +46,23 @@ const oneStrockInfo = [
 
 const ItmeImageStroke = ({ itemInfo }) => {
   const divideNum = itemInfo.category === "tumbler" ? 3 : 1;
-  const currentUsageCount = checkItemUsageCount(itemInfo.id, divideNum);
-  const [usageCount, setUsageCount] = useState(currentUsageCount);
+  const [usageCount, setUsageCount] = useState(itemInfo.usageCountPerDay);
   const queryClient = useQueryClient();
   const upUsageCountMutation = useMutation({
     mutationFn: patchUsageCountUp,
     onSuccess: () => {
       const newItemInfo = { ...itemInfo };
       newItemInfo.currentUsageCount += 1;
+      newItemInfo.usageCountPerDay += 1;
       queryClient.setQueryData(["title", itemInfo.category], newItemInfo);
       queryClient.invalidateQueries(["title", itemInfo.category]);
       queryClient.invalidateQueries([itemInfo.category, "list"]);
     },
   });
   const increaseCount = useCallback(() => {
-    if (usageCount > 0) {
+    if (usageCount < divideNum) {
       setUsageCount((currUsageCount) => {
-        const changeCout = currUsageCount > 1 ? currUsageCount - 1 : 0;
-        localStorage.setItem(
-          `item/${itemInfo.id}`,
-          JSON.stringify({
-            count: changeCout,
-            dateStr: makeDateStr(),
-          })
-        );
-        return changeCout;
+        return currUsageCount + 1;
       });
       upUsageCountMutation.mutate(itemInfo.id);
     }
@@ -103,7 +78,7 @@ const ItmeImageStroke = ({ itemInfo }) => {
           />
         </foreignObject>
         {(divideNum === 3 ? threeStrockInfo : oneStrockInfo).map((element) => {
-          if (element.key <= usageCount)
+          if (element.key <= divideNum - usageCount)
             return <S.StrokePath d={element.d} key={element.key} />;
           return (
             <S.StrokePath


### PR DESCRIPTION
## 개요
아이템 하루 사용량 서버데이터 연동

## 작업사항
- 아이템 사용량 관리 로컬스토리지->서버데이터로 변경
- `divideNum - usageCount`로 남은 사용량 계산
- 제한 사용량 이상 사용한 경우, 서버에서 횟수 증가되지 않도록 막은 로직 테스트 완료 (물론 프론트도 가드 되어있지만!)
  - 오류로 주면 핸들링도 추가하려고 했는데 200 + 횟수는 증가 안 시키게 처리했길래 확인만 하고 따로 핸들링 코드 없습니다!

## 변경로직
로컬스토리지에 하루 사용량 저장하는 코드 삭제~!

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->