### PR TITLE
feat: 500 에러 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect } from "react";
 import { Routes, Route, BrowserRouter } from "react-router-dom";
 import loadable from "@loadable/component";
 
-import { Home, Item, Setting, Login, SignUp, Error } from "@pages";
+import { Home, Item, Setting, Login, SignUp, Error, ServerError } from "@pages";
 import { PrivateLayout, PublicLayout } from "@layout";
 
 import { AuthenticatedContext } from "@hooks/AuthenticatedContext";
@@ -61,6 +61,7 @@ function PrivateRouter() {
           <Route path="/item/add" element={<ItemAdd />} />
         </Route>
         <Route path="/expire" element={<Expire />} />
+        <Route path="/500" element={<ServerError />} />
         <Route path="/*" element={<Error />} />
       </Routes>
     </BrowserRouter>
@@ -76,6 +77,7 @@ function PublicRouter() {
           <Route path="/login/*" element={<Login />} />
           <Route path="/signup" element={<SignUp />} />
           <Route path="/expire" element={<Expire />} />
+          <Route path="/500" element={<ServerError />} />
           <Route path="/*" element={<Error />} />
           {/* TODO: 아이템 조작 관련 페이지 모달로 바뀔 예정 */}
           <Route path="/item/edit" element={<ItemEdit />} />

--- a/src/components/logo/Logo.jsx
+++ b/src/components/logo/Logo.jsx
@@ -1,0 +1,6 @@
+import React from "react";
+import { LogoImg } from "./style";
+
+export default function Logo({ handleClick }) {
+  return <LogoImg src="/logo.png" alt="ecopercent" onClick={handleClick} />;
+}

--- a/src/components/logo/LogoBox.jsx
+++ b/src/components/logo/LogoBox.jsx
@@ -1,0 +1,10 @@
+import React from "react";
+import { LogoImg, LogoWrapper } from "./style";
+
+export default function LogoBox({ handleClick }) {
+  return (
+    <LogoWrapper onClick={handleClick}>
+      <LogoImg src="/logo.png" alt="ecopercent" />
+    </LogoWrapper>
+  );
+}

--- a/src/components/logo/style.jsx
+++ b/src/components/logo/style.jsx
@@ -1,0 +1,21 @@
+import styled from "@emotion/styled";
+
+export const LogoWrapper = styled.div`
+  margin-top: 15%;
+
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      cursor: pointer;
+    }
+  }
+`;
+
+export const LogoImg = styled.img`
+  width: 35px;
+
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      opacity: 0.8;
+    }
+  }
+`;

--- a/src/hooks/useAxiosInterceptor.js
+++ b/src/hooks/useAxiosInterceptor.js
@@ -41,13 +41,8 @@ export function useAxiosInterceptor() {
   }
 
   async function errorHandler(error) {
-    // TODO: 서버 에러 페이지 만들기?
-    // if (error.response.status >= 500) window.location.replace("/500");
-    if (
-      (error.config.url === "/signout" ||
-        error.config.url === "/token/access") &&
-      error.response.status !== 500
-    )
+    if (error.response.status >= 500) window.location.href = "/500";
+    if (error.config.url === "/signout" || error.config.url === "/token/access")
       return Promise.resolve("SIGNOUT");
     if (error.response.status === 403) {
       onAccessTokenExpire();

--- a/src/layout/private/navBar/NabBar.jsx
+++ b/src/layout/private/navBar/NabBar.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 
 import NabItem from "./NabItem";
+import Logo from "@components/logo/Logo";
 
 import {
   AiFillHome,
@@ -42,7 +43,7 @@ const NabBar = () => {
           navigate("/home");
         }}
       >
-        <S.Logo src="/logo.png" alt="ecopercent" />
+        <Logo />
       </S.LogoWrapper>
       {routeInfo.map((element) => {
         return (

--- a/src/layout/private/navBar/style.jsx
+++ b/src/layout/private/navBar/style.jsx
@@ -46,10 +46,6 @@ export const LogoWrapper = styled.div`
   }
 `;
 
-export const Logo = styled.img`
-  width: 35px;
-`;
-
 export const LinkWrapper = styled.div`
   @media ${media.desktop}, ${media.tabletMin} and ${media.tabletMax} {
     display: flex;

--- a/src/pages/error/server/index.jsx
+++ b/src/pages/error/server/index.jsx
@@ -15,8 +15,7 @@ export default function ServerError() {
         문제가 지속되는 경우 개발팀에 문의해 주세요.
       </S.NotificationText>
       <S.Line />
-      {/* TODO: 고객 지원 페이지 연결 */}
-      <S.Anchor href="https://github.com/ecopercent">Support</S.Anchor>
+      <S.Anchor href="mailto:ecopercent@gmail.com">Support</S.Anchor>
       <LogoBox
         handleClick={() => {
           navigate("/");

--- a/src/pages/error/server/index.jsx
+++ b/src/pages/error/server/index.jsx
@@ -15,6 +15,7 @@ export default function ServerError() {
         문제가 지속되는 경우 개발팀에 문의해 주세요.
       </S.NotificationText>
       <S.Line />
+      {/* TODO: 고객 지원 페이지 연결 */}
       <S.Anchor href="https://github.com/ecopercent">Support</S.Anchor>
       <LogoBox
         handleClick={() => {

--- a/src/pages/error/server/index.jsx
+++ b/src/pages/error/server/index.jsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { useNavigate } from "react-router-dom";
+import LogoBox from "@components/logo/LogoBox";
+import * as S from "../style";
+
+export default function ServerError() {
+  const navigate = useNavigate();
+  return (
+    <S.PageLayout>
+      <S.WarningIcon />
+      <S.Headline>페이지를 표시할 수 없습니다</S.Headline>
+      <S.NotificationText>
+        잠시 후 다시 시도해주세요.
+        <br />
+        문제가 지속되는 경우 개발팀에 문의해 주세요.
+      </S.NotificationText>
+      <S.Line />
+      <S.Anchor href="https://github.com/ecopercent">Support</S.Anchor>
+      <LogoBox
+        handleClick={() => {
+          navigate("/");
+        }}
+      />
+    </S.PageLayout>
+  );
+}

--- a/src/pages/error/style.jsx
+++ b/src/pages/error/style.jsx
@@ -12,7 +12,7 @@ export const WarningIcon = styled(BsFillPatchExclamationFill)`
 `;
 
 export const PageLayout = styled.div`
-  height: 100%;
+  height: calc(var(--vh, 1vh) * 100);
 
   display: flex;
   flex-direction: column;
@@ -30,7 +30,8 @@ export const Headline = styled.h2`
 export const NotificationText = styled.span`
   ${font.boldHeadline};
   font-weight: 400;
-  margin: 40px;
+  margin: 40px 0;
+  line-height: 2;
 `;
 
 export const GoHomeBtn = styled.button`
@@ -42,6 +43,30 @@ export const GoHomeBtn = styled.button`
   @media (hover: hover) and (pointer: fine) {
     :hover {
       background: ${basicGreen};
+    }
+  }
+`;
+
+export const Line = styled.div`
+  margin-top: 20px;
+  height: 1px;
+  width: 150px;
+  background-color: black;
+`;
+
+export const Anchor = styled.a`
+  color: gray;
+  text-decoration: none;
+  text-align: center;
+
+  width: 80px;
+  background-color: white;
+  translate: 0 -50%;
+
+  @media (hover: hover) and (pointer: fine) {
+    :hover {
+      cursor: pointer;
+      text-decoration: underline;
     }
   }
 `;

--- a/src/pages/expire/index.jsx
+++ b/src/pages/expire/index.jsx
@@ -3,6 +3,7 @@ import { Navigate, useNavigate } from "react-router-dom";
 
 import { AuthenticatedContext } from "@hooks/AuthenticatedContext";
 
+import LogoBox from "@components/logo/LogoBox";
 import * as S from "../error/style";
 
 export default function TokenExpiration() {
@@ -36,6 +37,11 @@ export default function TokenExpiration() {
       >
         메인 화면
       </S.GoHomeBtn>
+      <LogoBox
+        handleClick={() => {
+          navigate("/");
+        }}
+      />
     </S.PageLayout>
   );
 }

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -5,3 +5,4 @@ export { default as Login } from "@pages/login";
 export { default as SignUp } from "@pages/signup";
 export { default as Error } from "@pages/error";
 export { default as TokenExpiration } from "@pages/expire";
+export { default as ServerError } from "@pages/error/server";


### PR DESCRIPTION
## 개요
- 500 에러페이지 구현

## 작업사항
- 테스트 하다보니 서버 끊길 때 500 에러 페이지가 있는게 좋을듯하여 구현
- 에러 페이지에 에코 정체성이 없는듯 해서 로고 추가
- 로고 컴포넌트로 분리
- 리프레시 토큰 만료 페이지에도 로고 추가
- axios interceptor에 500 응답 시 페이지 이동하는 로직 추가
- 에러 페이지 Support에 고객지원 이메일 연결

ECOPERCENT-503

<!--
## 주의사항
- PR 제목의 형식은 커밋 메시지의 제목 형식과 동일하다.
- 제목에는 이 PR이 무엇을 했는지 명시해주기
- ex) feat: 로그인 토큰 발행 기능 추가
-->